### PR TITLE
UIPFAUTH-7: Create an empty modal window for find Authorities plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,6 +64,7 @@
     }],
     "react/no-array-index-key": "error",
     "react/no-multi-comp": "error",
+    "react/require-default-props": "error",
     "react/jsx-key": "error",
     "react/jsx-max-props-per-line": "error",
     "object-curly-newline": ["error", {

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,10 @@
     }, {
       "files": ["test/jest/**/*"],
       "rules": {
-        "react/prop-types": "off"
+        "react/prop-types": "off",
+        "react/no-array-index-key": "off",
+        "react/function-component-definition": "off",
+        "multiline-ternary": "off"
       }
     }
   ],
@@ -59,10 +62,8 @@
     "react/function-component-definition": [2, {
       "namedComponents": "arrow-function"
     }],
-    "react/hook-use-state": "error",
     "react/no-array-index-key": "error",
     "react/no-multi-comp": "error",
-    "react/require-default-props": "error",
     "react/jsx-key": "error",
     "react/jsx-max-props-per-line": "error",
     "object-curly-newline": ["error", {

--- a/.eslintrc
+++ b/.eslintrc
@@ -62,6 +62,7 @@
     "react/function-component-definition": [2, {
       "namedComponents": "arrow-function"
     }],
+    "react/hook-use-state": "error",
     "react/no-array-index-key": "error",
     "react/no-multi-comp": "error",
     "react/require-default-props": "error",

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 yarn.lock
 artifacts
 junit.xml
+yarn-error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 ## [0.1.0] (IN PROGRESS)
+
+* Create an empty modal window for find Authorities plugin. Refs UIPFAUTH-7

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "core-js": "^3.6.4",
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.1.3",
+    "eslint-plugin-react": "^7.30.1",
     "identity-obj-proxy": "^3.0.0",
     "inflected": "^2.0.4",
     "jest": "^26.4.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "jest",
+    "test": "jest --coverage --verbose",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json",
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-plugin-find-authority ./translations/ui-plugin-find-authority/compiled"
   },

--- a/src/FindAuthority.js
+++ b/src/FindAuthority.js
@@ -1,5 +1,58 @@
-const FindAuthority = () => {
-  return 'FindAuthority';
+import { useState } from 'react';
+import { useIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+
+import { IconButton } from '@folio/stripes-components';
+
+import { SearchModal } from './components';
+
+const propTypes = {
+  renderCustomTrigger: PropTypes.func,
 };
+
+const FindAuthority = ({
+  renderCustomTrigger,
+}) => {
+  const intl = useIntl();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
+  const renderDefaultTrigger = () => {
+    return (
+      <IconButton
+        icon="link"
+        aria-haspopup="true"
+        title={intl.formatMessage({ id: 'ui-plugin-find-authority.linkToMarcAuthorityRecord' })}
+        ariaLabel={intl.formatMessage({ id: 'ui-plugin-find-authority.linkToMarcAuthorityRecord' })}
+        onClick={openModal}
+      />
+    );
+  };
+
+  const renderTrigger = () => {
+    return renderCustomTrigger
+      ? renderCustomTrigger({ onClick: openModal })
+      : renderDefaultTrigger();
+  };
+
+  return (
+    <>
+      {renderTrigger()}
+      <SearchModal
+        open={isOpen}
+        onClose={closeModal}
+      />
+    </>
+  );
+};
+
+FindAuthority.propTypes = propTypes;
 
 export default FindAuthority;

--- a/src/FindAuthority.js
+++ b/src/FindAuthority.js
@@ -10,6 +10,10 @@ const propTypes = {
   renderCustomTrigger: PropTypes.func,
 };
 
+const defaultProps = {
+  renderCustomTrigger: null,
+};
+
 const FindAuthority = ({
   renderCustomTrigger,
 }) => {
@@ -54,5 +58,6 @@ const FindAuthority = ({
 };
 
 FindAuthority.propTypes = propTypes;
+FindAuthority.defaultProps = defaultProps;
 
 export default FindAuthority;

--- a/src/FindAuthority.test.js
+++ b/src/FindAuthority.test.js
@@ -1,18 +1,49 @@
 import {
   render,
   screen,
+  fireEvent,
+  cleanup,
 } from '@testing-library/react';
 
 import FindAuthority from './FindAuthority';
+import { SearchModal } from './components';
 
-const renderFindAuthority = () => render(
-    <FindAuthority
-    />
+jest.mock('./components', () => ({
+  SearchModal: jest.fn(() => <div>SearchModal</div>),
+}));
+
+const renderFindAuthority = (props = {}) => render(
+  <FindAuthority
+    {...props}
+  />,
 );
 
 describe('Given FindAuthority', () => {
-  it('should be rendered', () => {
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
     renderFindAuthority();
-    expect(screen.getByText('FindAuthority')).toBeVisible();
+  });
+
+  describe('when component does not get renderCustomTrigger action', () => {
+    it('should render default trigger', () => {
+      expect(screen.getByRole('button', { name: 'ui-plugin-find-authority.linkToMarcAuthorityRecord' })).toBeVisible();
+    });
+  });
+
+  describe('when component get renderCustomTrigger action', () => {
+    it('should handle renderCustomTrigger', () => {
+      const renderCustomTrigger = jest.fn();
+
+      renderFindAuthority({ renderCustomTrigger });
+      expect(renderCustomTrigger).toHaveBeenCalled();
+    });
+  });
+
+  describe('when a user clicks on the default modal trigger', () => {
+    it('should open the modal window', () => {
+      fireEvent.click(screen.getByRole('button', { name: 'ui-plugin-find-authority.linkToMarcAuthorityRecord' }));
+      expect(SearchModal.mock.calls[1][0].open).toBeTruthy();
+    });
   });
 });

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -1,0 +1,31 @@
+import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
+
+import { Modal } from '@folio/stripes-components';
+
+const propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+};
+
+const SearchModal = ({
+  open,
+  onClose,
+}) => {
+  return (
+    <Modal
+      dismissible
+      label={<FormattedMessage id="ui-find-authority.modal.title" />}
+      open={open}
+      size="large"
+      data-testid="find-authority-modal"
+      onClose={onClose}
+    >
+      Search modal
+    </Modal>
+  );
+};
+
+SearchModal.propTypes = propTypes;
+
+export default SearchModal;

--- a/src/components/SearchModal/SearchModal.test.js
+++ b/src/components/SearchModal/SearchModal.test.js
@@ -1,0 +1,31 @@
+import {
+  render,
+  screen,
+  cleanup,
+} from '@testing-library/react';
+
+import SearchModal from './SearchModal';
+
+const requiredProps = {
+  open: true,
+  onClose: jest.fn(),
+};
+
+const renderSearchModal = (props = {}) => render(
+  <SearchModal
+    {...requiredProps}
+    {...props}
+  />,
+);
+
+describe('Given SearchModal', () => {
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+    renderSearchModal();
+  });
+
+  it('should be visible', () => {
+    expect(screen.getByTestId('find-authority-modal')).toBeInTheDocument();
+  });
+});

--- a/src/components/SearchModal/index.js
+++ b/src/components/SearchModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchModal';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,1 @@
+export { default as SearchModal } from './SearchModal';

--- a/translations/ui-plugin-find-authority/en.json
+++ b/translations/ui-plugin-find-authority/en.json
@@ -1,3 +1,5 @@
 {
-  "meta.title": "Authority finder (plugin)"
+  "meta.title": "Authority finder (plugin)",
+  "linkToMarcAuthorityRecord": "Link to MARC authority record",
+  "modal.title": "Select MARC authority"
 }


### PR DESCRIPTION
## Purpose
Create an empty modal window
## Issues
[UIPFAUTH-7](https://issues.folio.org/browse/UIPFAUTH-7)