### PR TITLE
UIPFAUTH-5: Select a MARC authority record modal > View a MARC authority detail record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 * Create an empty modal window for find Authorities plugin. Refs UIPFAUTH-7
 * Select a MARC authority record modal > Results list - Search. Refs UIPFAUTH-3
 * Select a MARC authority record modal > Results list - Browse. Refs UIPFAUTH-4
+* Select a MARC authority record modal > View a MARC authority detail record. Refs UIPFAUTH-5

--- a/src/FindAuthority.js
+++ b/src/FindAuthority.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { IconButton } from '@folio/stripes-components';
+import { IconButton } from '@folio/stripes/components';
 import {
   AuthoritiesSearchContextProvider,
   SelectedAuthorityRecordContextProvider,

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.css
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.css
@@ -1,0 +1,3 @@
+.link {
+    composes: root from '~@folio/stripes-components/lib/TextLink/TextLink.css';
+}

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { Pane } from '@folio/stripes/components';
-import { AppIcon } from '@folio/stripes-core';
+import { AppIcon } from '@folio/stripes/core';
 import {
   AuthoritiesSearchContext,
   AuthoritiesSearchPane,

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -76,7 +76,8 @@ const AuthoritiesLookup = ({
       setSelectedAuthorityRecordContext(authorities[0]);
       setShowDetailView(true);
     }
-  }, [totalRecords, authorities, navigationSegmentValue])
+    // eslint-disable-next-line
+  }, [totalRecords, authorities, navigationSegmentValue]);
 
   const handleSubmitSearch = (e, ...rest) => {
     if (e?.preventDefault) {

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -59,7 +59,7 @@ const AuthoritiesLookup = ({
   const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
   const [showDetailView, setShowDetailView] = useState(false);
 
-  const { navigationSegmentValue } = useContext(AuthoritiesSearchContext);
+  const { navigationSegmentValue, filters } = useContext(AuthoritiesSearchContext);
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
   const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
@@ -68,6 +68,11 @@ const AuthoritiesLookup = ({
     setShowDetailView(false);
     setSelectedAuthorityRecordContext(null);
   };
+
+  useEffect(() => {
+    closeDetailView();
+    // eslint-disable-next-line
+  }, [filters]);
 
   useEffect(() => {
     const isDetailViewNeedsToBeOpened = getIsDetailViewNeedsToBeOpened(totalRecords, authorities[0], navigationSegmentValue);
@@ -152,7 +157,6 @@ const AuthoritiesLookup = ({
         query={query}
         height={MAIN_PANE_HEIGHT}
         onShowDetailView={setShowDetailView}
-        onCloseDetailView={closeDetailView}
       />
       {showDetailView
         ? (

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -1,0 +1,165 @@
+import {
+  useContext,
+  useState,
+} from 'react';
+import { useIntl } from 'react-intl';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+import { Pane } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core';
+import {
+  AuthoritiesSearchPane,
+  AuthorityShape,
+  SearchResultsList,
+  SelectedAuthorityRecordContext,
+  useAutoOpenDetailView,
+} from '@folio/stripes-authority-components';
+
+import MarcAuthorityView from '../MarcAuthorityView';
+import {
+  columnWidths,
+  MAIN_PANE_HEIGHT,
+  PAGE_SIZE,
+} from '../../constants';
+import css from './AuthoritiesLookup.css';
+
+const propTypes = {
+  authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
+  hasFilters: PropTypes.bool.isRequired,
+  hasNextPage: PropTypes.bool,
+  hasPrevPage: PropTypes.bool,
+  hidePageIndices: PropTypes.bool,
+  isLoaded: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  onNeedMoreData: PropTypes.func.isRequired,
+  onSubmitSearch: PropTypes.func.isRequired,
+  query: PropTypes.string.isRequired,
+  searchQuery: PropTypes.string.isRequired,
+  totalRecords: PropTypes.number.isRequired,
+};
+
+const AuthoritiesLookup = ({
+  authorities,
+  totalRecords,
+  searchQuery,
+  query,
+  isLoaded,
+  isLoading,
+  hasFilters,
+  hasNextPage,
+  hasPrevPage,
+  hidePageIndices,
+  onNeedMoreData,
+  onSubmitSearch,
+}) => {
+  const intl = useIntl();
+  const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
+  const [showDetailView, setShowDetailView] = useState(false);
+
+  const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
+
+  useAutoOpenDetailView({ authorities, totalRecords, setShowDetailView });
+
+  const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
+
+  const closeDetailView = () => {
+    setShowDetailView(false);
+    setSelectedAuthorityRecordContext(null);
+  };
+
+  const handleSubmitSearch = (e, ...rest) => {
+    if (e?.preventDefault) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    closeDetailView();
+    onSubmitSearch(e, ...rest);
+  };
+
+  const renderPaneSub = () => {
+    return (
+      <span>
+        {intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.paneSub' }, {
+          totalRecords,
+        })}
+      </span>
+    );
+  };
+
+  const renderHeadingRef = (authority, className) => (
+    <button
+      type="button"
+      className={classNames(css.link, className)}
+      onClick={() => setShowDetailView(true)}
+    >
+      {authority.headingRef}
+    </button>
+  );
+
+  const renderResultList = () => (
+    <Pane
+      id="authority-search-results-pane"
+      appIcon={<AppIcon app="marc-authorities" />}
+      defaultWidth="fill"
+      paneTitle={intl.formatMessage({ id: 'stripes-authority-components.meta.title' })}
+      paneSub={renderPaneSub()}
+      padContent={false}
+      noOverflow
+      height={MAIN_PANE_HEIGHT}
+    >
+      <SearchResultsList
+        authorities={authorities}
+        columnWidths={columnWidths}
+        totalResults={totalRecords}
+        pageSize={PAGE_SIZE}
+        onNeedMoreData={onNeedMoreData}
+        loading={isLoading}
+        loaded={isLoaded}
+        visibleColumns={['authRefType', 'headingRef', 'headingType']}
+        isFilterPaneVisible={isFilterPaneVisible}
+        toggleFilterPane={toggleFilterPane}
+        hasFilters={hasFilters}
+        query={searchQuery}
+        hasNextPage={hasNextPage}
+        hasPrevPage={hasPrevPage}
+        hidePageIndices={hidePageIndices}
+        onRenderHeadingRef={renderHeadingRef}
+      />
+    </Pane>
+  );
+
+  return (
+    <>
+      <AuthoritiesSearchPane
+        isFilterPaneVisible={isFilterPaneVisible}
+        toggleFilterPane={toggleFilterPane}
+        isLoading={isLoading}
+        onSubmitSearch={handleSubmitSearch}
+        query={query}
+        height={MAIN_PANE_HEIGHT}
+        onShowDetailView={setShowDetailView}
+        onCloseDetailView={closeDetailView}
+      />
+      {showDetailView
+        ? (
+          <MarcAuthorityView
+            onCloseDetailView={closeDetailView}
+          />
+        )
+        : renderResultList()
+      }
+    </>
+  );
+};
+
+AuthoritiesLookup.propTypes = propTypes;
+
+AuthoritiesLookup.defaultProps = {
+  hasNextPage: null,
+  hasPrevPage: null,
+  hidePageIndices: false,
+};
+
+export default AuthoritiesLookup;

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -1,5 +1,6 @@
 import {
   useContext,
+  useEffect,
   useState,
 } from 'react';
 import { useIntl } from 'react-intl';
@@ -9,11 +10,12 @@ import PropTypes from 'prop-types';
 import { Pane } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes-core';
 import {
+  AuthoritiesSearchContext,
   AuthoritiesSearchPane,
   AuthorityShape,
+  autoOpenDetailView,
   SearchResultsList,
   SelectedAuthorityRecordContext,
-  useAutoOpenDetailView,
 } from '@folio/stripes-authority-components';
 
 import MarcAuthorityView from '../MarcAuthorityView';
@@ -57,9 +59,8 @@ const AuthoritiesLookup = ({
   const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
   const [showDetailView, setShowDetailView] = useState(false);
 
+  const { navigationSegmentValue } = useContext(AuthoritiesSearchContext);
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
-
-  useAutoOpenDetailView({ authorities, totalRecords, setShowDetailView });
 
   const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
 
@@ -67,6 +68,15 @@ const AuthoritiesLookup = ({
     setShowDetailView(false);
     setSelectedAuthorityRecordContext(null);
   };
+
+  useEffect(() => {
+    const isDetailViewNeedsToBeOpened = autoOpenDetailView(totalRecords, authorities[0], navigationSegmentValue);
+
+    if (isDetailViewNeedsToBeOpened) {
+      setSelectedAuthorityRecordContext(authorities[0]);
+      setShowDetailView(true);
+    }
+  }, [totalRecords, authorities, navigationSegmentValue])
 
   const handleSubmitSearch = (e, ...rest) => {
     if (e?.preventDefault) {
@@ -101,6 +111,7 @@ const AuthoritiesLookup = ({
   const renderResultList = () => (
     <Pane
       id="authority-search-results-pane"
+      data-testid="authority-search-results-pane"
       appIcon={<AppIcon app="marc-authorities" />}
       defaultWidth="fill"
       paneTitle={intl.formatMessage({ id: 'stripes-authority-components.meta.title' })}

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -13,7 +13,7 @@ import {
   AuthoritiesSearchContext,
   AuthoritiesSearchPane,
   AuthorityShape,
-  navigationSegments,
+  getIsDetailViewNeedsToBeOpened,
   SearchResultsList,
   SelectedAuthorityRecordContext,
 } from '@folio/stripes-authority-components';
@@ -70,14 +70,7 @@ const AuthoritiesLookup = ({
   };
 
   useEffect(() => {
-    if (totalRecords !== 1) {
-      return;
-    }
-
-    const firstAuthority = authorities[0];
-    const isDetailViewNeedsToBeOpened = navigationSegmentValue === navigationSegments.browse
-      ? firstAuthority?.isAnchor && firstAuthority?.isExactMatch
-      : true;
+    const isDetailViewNeedsToBeOpened = getIsDetailViewNeedsToBeOpened(totalRecords, authorities[0], navigationSegmentValue);
 
     if (isDetailViewNeedsToBeOpened) {
       setSelectedAuthorityRecordContext(authorities[0]);
@@ -144,7 +137,7 @@ const AuthoritiesLookup = ({
         hasNextPage={hasNextPage}
         hasPrevPage={hasPrevPage}
         hidePageIndices={hidePageIndices}
-        onRenderHeadingRef={renderHeadingRef}
+        renderHeadingRef={renderHeadingRef}
       />
     </Pane>
   );

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -13,7 +13,7 @@ import {
   AuthoritiesSearchContext,
   AuthoritiesSearchPane,
   AuthorityShape,
-  autoOpenDetailView,
+  navigationSegments,
   SearchResultsList,
   SelectedAuthorityRecordContext,
 } from '@folio/stripes-authority-components';
@@ -70,7 +70,14 @@ const AuthoritiesLookup = ({
   };
 
   useEffect(() => {
-    const isDetailViewNeedsToBeOpened = autoOpenDetailView(totalRecords, authorities[0], navigationSegmentValue);
+    if (totalRecords !== 1) {
+      return;
+    }
+
+    const firstAuthority = authorities[0];
+    const isDetailViewNeedsToBeOpened = navigationSegmentValue === navigationSegments.browse
+      ? firstAuthority?.isAnchor && firstAuthority?.isExactMatch
+      : true;
 
     if (isDetailViewNeedsToBeOpened) {
       setSelectedAuthorityRecordContext(authorities[0]);

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -55,13 +55,6 @@ describe('Given AuthoritiesLookup', () => {
   });
 
   describe('when there is only one record', () => {
-    // beforeEach(() => {
-    //   renderAuthoritiesSearchPane({
-    //     authorities: [authorities[0]],
-    //     totalRecords: 1,
-    //   });
-    // });
-
     it('should add authority record to the context', () => {
       renderAuthoritiesSearchPane({
         authorities: [authorities[0]],

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -1,10 +1,9 @@
 import { render, screen } from '@testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
-import authorities from '@folio/stripes-authority-components/mocks/authorities.json';
+import authorities from '@folio/stripes-authority-components/mocks/authorities.json'; // eslint-disable-line import/extensions
 
 import AuthoritiesLookup from './AuthoritiesLookup';
-import MarcAuthorityView from '../MarcAuthorityView';
 
 import Harness from '../../../test/jest/helpers/harness';
 
@@ -60,7 +59,7 @@ describe('Given AuthoritiesLookup', () => {
   it('should display the results pane', () => {
     renderAuthoritiesSearchPane();
     expect(screen.getByTestId('authority-search-results-pane')).toBeDefined();
-  })
+  });
 
   describe('when there is only one record', () => {
     beforeEach(() => {
@@ -76,6 +75,6 @@ describe('Given AuthoritiesLookup', () => {
 
     it('should display the detail view', () => {
       expect(screen.getByText('MarcAuthorityView')).toBeVisible();
-    })
+    });
   });
 });

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -1,0 +1,80 @@
+import { render } from '@testing-library/react';
+
+import { runAxeTest } from '@folio/stripes-testing';
+
+import { useAutoOpenDetailView } from '@folio/stripes-authority-components';
+import AuthoritiesLookup from './AuthoritiesLookup';
+
+import Harness from '../../../test/jest/helpers/harness';
+
+jest.mock('@folio/stripes-authority-components', () => ({
+  ...jest.requireActual('@folio/stripes-authority-components'),
+  useAuthorities: () => ({ authorities: [] }),
+  useAutoOpenDetailView: jest.fn(),
+}));
+
+jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
+
+const mockAuthorities = [{
+  'id': '5a404f5d-2c46-4426-9f28-db8d26881b30',
+  'headingType': 'Personal name',
+  'authRefType': 'Auth/Ref',
+  'headingRef': 'Twain, Mark',
+}];
+
+const renderAuthoritiesSearchPane = (props = {}) => render(
+  <Harness>
+    <AuthoritiesLookup
+      authorities={mockAuthorities}
+      hasFilters={false}
+      isLoaded={false}
+      isLoading={false}
+      query=""
+      searchQuery=""
+      totalRecords={mockAuthorities.length}
+      onNeedMoreData={jest.fn()}
+      onSubmitSearch={jest.fn()}
+      {...props}
+    />
+  </Harness>,
+);
+
+describe('Given AuthoritiesLookup', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderAuthoritiesSearchPane();
+
+    await runAxeTest({
+      rootNode: container,
+    });
+  });
+
+  it('should display AuthoritiesSearchPane', () => {
+    const { getByTestId } = renderAuthoritiesSearchPane();
+
+    expect(getByTestId('pane-authorities-filters')).toBeDefined();
+  });
+
+  it('should check if detail view needs to be opened', () => {
+    const authorities = [{
+      'id': '5a404f5d-2c46-4426-9f28-db8d26881b30',
+      'headingType': 'Personal name',
+      'authRefType': 'Auth/Ref',
+      'headingRef': 'Twain, Mark',
+    }];
+    const totalRecords = 1;
+
+    renderAuthoritiesSearchPane({
+      authorities,
+      totalRecords,
+    });
+    expect(useAutoOpenDetailView).toHaveBeenCalledWith({
+      authorities: mockAuthorities,
+      setShowDetailView: expect.any(Function),
+      totalRecords: mockAuthorities.length,
+    });
+  });
+});

--- a/src/components/AuthoritiesLookup/index.js
+++ b/src/components/AuthoritiesLookup/index.js
@@ -1,0 +1,1 @@
+export { default } from './AuthoritiesLookup';

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -7,7 +7,6 @@ import { Loading } from '@folio/stripes/components';
 import {
   useMarcSource,
   useAuthority,
-  markHighlightedFields,
   QUERY_KEY_AUTHORITY_SOURCE,
   SelectedAuthorityRecordContext,
 } from '@folio/stripes-authority-components';
@@ -17,6 +16,8 @@ import {
 } from '@folio/stripes-core';
 import MarcView from '@folio/quick-marc/src/QuickMarcView/QuickMarcView';
 
+import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set';
 import { MAIN_PANE_HEIGHT } from '../../constants';
 
 const propTypes = {
@@ -32,6 +33,45 @@ const MarcAuthorityView = ({
   const intl = useIntl();
   const [selectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
   const { id, authRefType, headingRef } = selectedAuthorityRecordContext;
+
+  const markHighlightedFields = (marcSource, authority) => {
+    const highlightAuthRefFields = {
+      'Authorized': /1\d\d/,
+      'Reference': /4\d\d/,
+      'Auth/Ref': /5\d\d/,
+    };
+
+    const marcFields = marcSource.data.parsedRecord.content.fields.map(field => {
+      const tag = Object.keys(field)[0];
+
+      const isHighlightedTag = highlightAuthRefFields[authority.data.authRefType].test(tag);
+
+      if (!isHighlightedTag) {
+        return field;
+      }
+
+      const fieldContent = field[tag].subfields.reduce((contentArr, subfield) => {
+        const subfieldValue = Object.values(subfield)[0];
+
+        return [...contentArr, subfieldValue];
+      }, []).join(' ');
+
+      const isHeadingRefMatching = fieldContent === authority.data.headingRef;
+
+      return {
+        ...field,
+        [tag]: {
+          ...field[tag],
+          isHighlighted: isHeadingRefMatching && isHighlightedTag,
+        },
+      };
+    });
+    const marcSourceClone = cloneDeep(marcSource);
+
+    set(marcSourceClone, 'data.parsedRecord.content.fields', marcFields);
+
+    return marcSourceClone;
+  };
 
   const handleAuthorityLoadError = async err => {
     const errorResponse = await err.response;

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -77,8 +77,8 @@ const MarcAuthorityView = ({
     const errorResponse = await err.response;
 
     const calloutMessageId = errorResponse.status === 404
-      ? 'ui-marc-authorities.authority.view.error.notFound'
-      : 'ui-marc-authorities.authority.view.error.unknown';
+      ? 'stripes-authority-components.authority.view.error.notFound'
+      : 'stripes-authority-components.authority.view.error.unknown';
 
     callout.sendCallout({ type: 'error', message:  intl.formatMessage({ id: calloutMessageId }) });
     queryClient.invalidateQueries(authoritySourceNamespace);

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -1,0 +1,86 @@
+import { useContext } from 'react';
+import { useIntl } from 'react-intl';
+import { useQueryClient } from 'react-query';
+import PropTypes from 'prop-types';
+
+import { Loading } from '@folio/stripes/components';
+import {
+  useMarcSource,
+  useAuthority,
+  markHighlightedFields,
+  QUERY_KEY_AUTHORITY_SOURCE,
+  SelectedAuthorityRecordContext,
+} from '@folio/stripes-authority-components';
+import {
+  useCallout,
+  useNamespace,
+} from '@folio/stripes-core';
+import MarcView from '@folio/quick-marc/src/QuickMarcView/QuickMarcView';
+
+import { MAIN_PANE_HEIGHT } from '../../constants';
+
+const propTypes = {
+  onCloseDetailView: PropTypes.func.isRequired,
+};
+
+const MarcAuthorityView = ({
+  onCloseDetailView,
+}) => {
+  const queryClient = useQueryClient();
+  const authoritySourceNamespace = useNamespace({ key: QUERY_KEY_AUTHORITY_SOURCE });
+  const callout = useCallout();
+  const intl = useIntl();
+  const [selectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
+  const { id, authRefType, headingRef } = selectedAuthorityRecordContext;
+
+  const handleAuthorityLoadError = async err => {
+    const errorResponse = await err.response;
+
+    const calloutMessageId = errorResponse.status === 404
+      ? 'ui-marc-authorities.authority.view.error.notFound'
+      : 'ui-marc-authorities.authority.view.error.unknown';
+
+    callout.sendCallout({ type: 'error', message:  intl.formatMessage({ id: calloutMessageId }) });
+    queryClient.invalidateQueries(authoritySourceNamespace);
+  };
+
+  const marcSource = useMarcSource(id, {
+    onError: handleAuthorityLoadError,
+  });
+
+  const authority = useAuthority(id, authRefType, headingRef, {
+    onError: handleAuthorityLoadError,
+  });
+
+  if (marcSource.isLoading || authority.isLoading) {
+    return <Loading size="xlarge" />;
+  }
+
+  if (!marcSource.data || !authority.data) {
+    return null;
+  }
+
+  const paneSub = intl.formatMessage({ id: 'stripes-authority-components.authorityRecordSubtitle' }, {
+    heading: authority.data.headingType,
+    lastUpdatedDate: intl.formatDate(marcSource.data.metadata.updatedDate),
+  });
+
+  return (
+    <MarcView
+      paneWidth="fill"
+      paneHeight={MAIN_PANE_HEIGHT}
+      paneTitle={authority.data.headingRef}
+      paneSub={paneSub}
+      marcTitle={intl.formatMessage({ id: 'stripes-authority-components.marcHeading' })}
+      marc={markHighlightedFields(marcSource, authority).data}
+      onClose={onCloseDetailView}
+    />
+  );
+};
+
+MarcAuthorityView.propTypes = propTypes;
+MarcAuthorityView.dufaultProps = {
+  onCloseDetailView: null,
+};
+
+export default MarcAuthorityView;

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -13,7 +13,7 @@ import {
 import {
   useCallout,
   useNamespace,
-} from '@folio/stripes-core';
+} from '@folio/stripes/core';
 import MarcView from '@folio/quick-marc/src/QuickMarcView/QuickMarcView';
 
 import cloneDeep from 'lodash/cloneDeep';

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -9,6 +9,7 @@ import {
   useAuthority,
   QUERY_KEY_AUTHORITY_SOURCE,
   SelectedAuthorityRecordContext,
+  markHighlightedFields,
 } from '@folio/stripes-authority-components';
 import {
   useCallout,
@@ -16,8 +17,6 @@ import {
 } from '@folio/stripes/core';
 import MarcView from '@folio/quick-marc/src/QuickMarcView/QuickMarcView';
 
-import cloneDeep from 'lodash/cloneDeep';
-import set from 'lodash/set';
 import { MAIN_PANE_HEIGHT } from '../../constants';
 
 const propTypes = {
@@ -33,45 +32,6 @@ const MarcAuthorityView = ({
   const intl = useIntl();
   const [selectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
   const { id, authRefType, headingRef } = selectedAuthorityRecordContext;
-
-  const markHighlightedFields = (marcSource, authority) => {
-    const highlightAuthRefFields = {
-      'Authorized': /1\d\d/,
-      'Reference': /4\d\d/,
-      'Auth/Ref': /5\d\d/,
-    };
-
-    const marcFields = marcSource.data.parsedRecord.content.fields.map(field => {
-      const tag = Object.keys(field)[0];
-
-      const isHighlightedTag = highlightAuthRefFields[authority.data.authRefType].test(tag);
-
-      if (!isHighlightedTag) {
-        return field;
-      }
-
-      const fieldContent = field[tag].subfields.reduce((contentArr, subfield) => {
-        const subfieldValue = Object.values(subfield)[0];
-
-        return [...contentArr, subfieldValue];
-      }, []).join(' ');
-
-      const isHeadingRefMatching = fieldContent === authority.data.headingRef;
-
-      return {
-        ...field,
-        [tag]: {
-          ...field[tag],
-          isHighlighted: isHeadingRefMatching && isHighlightedTag,
-        },
-      };
-    });
-    const marcSourceClone = cloneDeep(marcSource);
-
-    set(marcSourceClone, 'data.parsedRecord.content.fields', marcFields);
-
-    return marcSourceClone;
-  };
 
   const handleAuthorityLoadError = async err => {
     const errorResponse = await err.response;

--- a/src/components/MarcAuthorityView/MarcAuthorityView.test.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.test.js
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+
+import { runAxeTest } from '@folio/stripes-testing';
+import authorities from '@folio/stripes-authority-components/mocks/authorities.json'; // eslint-disable-line import/extensions
+
+import MarcAuthorityView from './MarcAuthorityView';
+
+import Harness from '../../../test/jest/helpers/harness';
+
+jest.mock('@folio/quick-marc/src/QuickMarcView/QuickMarcView', () => jest.fn(() => <div>MarcView</div>));
+
+jest.mock('@folio/stripes-authority-components', () => ({
+  ...jest.requireActual('@folio/stripes-authority-components'),
+  useAuthority: () => ({
+    data: {},
+    isLoading: false,
+  }),
+  useMarcSource: jest.fn(() => ({
+    data: {
+      parsedRecord: { content: { fields: [] } },
+      metadata: {
+        updatedDate: '',
+      },
+    },
+    isLoading: false,
+  })),
+}));
+
+
+const mockSetSelectedAuthorityRecordContext = jest.fn();
+
+const getMarcAuthorityView = (props = {}, selectedRecord = authorities[0]) => (
+  <Harness selectedRecordCtxValue={[selectedRecord, mockSetSelectedAuthorityRecordContext]}>
+    <MarcAuthorityView
+      onCloseDetailView={jest.fn()}
+      {...props}
+    />
+  </Harness>
+);
+
+const renderMarcAuthorityView = (...params) => render(getMarcAuthorityView(...params));
+
+describe('Given MarcAuthorityView', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderMarcAuthorityView();
+
+    await runAxeTest({
+      rootNode: container,
+    });
+  });
+
+  it('should display MarcView', () => {
+    renderMarcAuthorityView();
+    expect(screen.getByText('MarcView')).toBeVisible();
+  });
+});

--- a/src/components/MarcAuthorityView/MarcAuthorityView.test.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.test.js
@@ -1,31 +1,94 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
 import authorities from '@folio/stripes-authority-components/mocks/authorities.json'; // eslint-disable-line import/extensions
+import {
+  useMarcSource,
+  useAuthority,
+} from '@folio/stripes-authority-components';
 
 import MarcAuthorityView from './MarcAuthorityView';
 
 import Harness from '../../../test/jest/helpers/harness';
 
-jest.mock('@folio/quick-marc/src/QuickMarcView/QuickMarcView', () => jest.fn(() => <div>MarcView</div>));
+const mockSendCallout = jest.fn();
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useCallout: () => ({
+    sendCallout: mockSendCallout,
+  }),
+}));
+
+const marcSource = {
+  data: {
+    parsedRecord: {
+      content: {
+        fields: [{
+          100: {
+            subfields: [{
+              a: 'heading-ref',
+            }],
+            ind1: '',
+            ind2: '',
+          },
+        }, {
+          110: {
+            subfields: [{
+              a: 'value contains heading-ref string',
+            }],
+            ind1: '',
+            ind2: '',
+          },
+        }, {
+          400: {
+            subfields: [{
+              a: 'heading-ref',
+            }],
+            ind1: '',
+            ind2: '',
+          },
+        }, {
+          410: {
+            subfields: [{
+              a: 'heading-ref',
+            }],
+            ind1: '',
+            ind2: '',
+          },
+        }, {
+          500: {
+            subfields: [{
+              a: 'heading-ref',
+            }],
+            ind1: '',
+            ind2: '',
+          },
+        }],
+      },
+    },
+    metadata: {
+      lastUpdatedDate: '2020-12-04T09:05:30.000+0000',
+      updatedDate: '',
+    },
+  },
+  isLoading: false,
+};
+
+const authority = {
+  data: {
+    id: 'authority-id',
+    headingRef: 'heading-ref',
+    authRefType: 'Authorized',
+  },
+  isLoading: false,
+};
 
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
-  useAuthority: () => ({
-    data: {},
-    isLoading: false,
-  }),
-  useMarcSource: jest.fn(() => ({
-    data: {
-      parsedRecord: { content: { fields: [] } },
-      metadata: {
-        updatedDate: '',
-      },
-    },
-    isLoading: false,
-  })),
+  useAuthority: jest.fn(() => authority),
+  useMarcSource: jest.fn(() => marcSource),
 }));
-
 
 const mockSetSelectedAuthorityRecordContext = jest.fn();
 
@@ -53,8 +116,98 @@ describe('Given MarcAuthorityView', () => {
     });
   });
 
-  it('should display MarcView', () => {
-    renderMarcAuthorityView();
-    expect(screen.getByText('MarcView')).toBeVisible();
+  describe('when authority record has authRefType Authorized', () => {
+    it('should highlight 1xx marc field', () => {
+      const { container } = renderMarcAuthorityView();
+      const highlightedContent = [...container.querySelectorAll('mark')].map(mark => mark.textContent).join(' ');
+
+      expect(highlightedContent).toEqual('heading-ref');
+    });
+  });
+
+  describe('when authority record has authRefType Reference', () => {
+    it('should highlight all 4xx marc fields', () => {
+      const mockAuthority = {
+        data: {
+          ...authority.data,
+          authRefType: 'Reference',
+        },
+        isLoading: false,
+      };
+
+      useAuthority.mockImplementation(() => mockAuthority);
+
+      const { container } = renderMarcAuthorityView();
+      const highlightedContent = [...container.querySelectorAll('mark')].map(mark => mark.textContent).join(' ');
+
+      expect(highlightedContent).toEqual('heading-ref heading-ref');
+    });
+  });
+
+  describe('when authority record has authRefType Auth/Ref', () => {
+    it('should highlight 5xx marc field', () => {
+      const mockAuthority = {
+        data: {
+          ...authority.data,
+          authRefType: 'Auth/Ref',
+        },
+        isLoading: false,
+      };
+
+      useAuthority.mockImplementation(() => mockAuthority);
+
+      const { container } = renderMarcAuthorityView();
+      const highlightedContent = [...container.querySelectorAll('mark')].map(mark => mark.textContent).join(' ');
+
+      expect(highlightedContent).toEqual('heading-ref');
+    });
+  });
+
+  describe('when tag value contains only part of authority heading ref value', () => {
+    it('should not highlight tag value', () => {
+      const { container } = renderMarcAuthorityView();
+      const highlightedContent = [...container.querySelectorAll('mark')].map(mark => mark.textContent).join(' ');
+
+      expect(highlightedContent).not.toEqual('value contains heading-ref string');
+    });
+  });
+
+  describe('when tag value completely equals to authority heading ref value', () => {
+    it('should highlight tag value', () => {
+      const mockAuthority = {
+        data: {
+          ...authority.data,
+          headingRef: 'value contains heading-ref string',
+        },
+        isLoading: false,
+      };
+
+      useAuthority.mockImplementation(() => mockAuthority);
+
+      const { container } = renderMarcAuthorityView();
+      const highlightedContent = [...container.querySelectorAll('mark')].map(mark => mark.textContent).join(' ');
+
+      expect(highlightedContent).toEqual('value contains heading-ref string');
+    });
+  });
+
+  describe('when marc source request failed', () => {
+    const responsePromise = Promise.resolve({ status: 404 });
+
+    beforeEach(() => {
+      useMarcSource.mockImplementation((id, { onError }) => onError({
+        response: responsePromise,
+      }));
+    });
+
+    it('should show error toast', async () => {
+      renderMarcAuthorityView();
+      await responsePromise;
+
+      expect(mockSendCallout).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'stripes-authority-components.authority.view.error.notFound',
+      });
+    });
   });
 });

--- a/src/components/MarcAuthorityView/index.js
+++ b/src/components/MarcAuthorityView/index.js
@@ -1,0 +1,1 @@
+export { default } from './MarcAuthorityView';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,1 +1,3 @@
 export { default as SearchModal } from './SearchModal';
+export { default as AuthoritiesLookup } from './AuthoritiesLookup';
+export { default as MarcAuthorityView } from './MarcAuthorityView';

--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -1,0 +1,9 @@
+import { searchResultListColumns } from '@folio/stripes-authority-components';
+
+export const MAIN_PANE_HEIGHT = '609px';
+export const columnWidths = {
+  [searchResultListColumns.SELECT]: { min: 30, max: 30 },
+  [searchResultListColumns.AUTH_REF_TYPE]: { min: 155, max: 166 },
+  [searchResultListColumns.HEADING_REF]: { min: 390, max: 435 },
+  [searchResultListColumns.HEADING_TYPE]: { min: 140, max: 145 },
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,1 +1,2 @@
 export * from './searchConstants';
+export * from './base';

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -1,35 +1,20 @@
 import {
-  useState,
   useContext,
   useMemo,
 } from 'react';
-import { useIntl } from 'react-intl';
 
-import { AppIcon } from '@folio/stripes/core';
 import {
-  Pane,
-  PaneMenu,
-} from '@folio/stripes/components';
-import { ExpandFilterPaneButton } from '@folio/stripes/smart-components';
-import {
-  AuthoritiesSearchPane,
-  SearchResultsList,
   AuthoritiesSearchContext,
-  SelectedAuthorityRecordContext,
   useAuthoritiesBrowse,
 } from '@folio/stripes-authority-components';
 
+import { AuthoritiesLookup } from '../../components';
 import {
   PAGE_SIZE,
   PRECEDING_RECORDS_COUNT,
 } from '../../constants';
 
 const BrowseView = () => {
-  const intl = useIntl();
-  const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
-
-  const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
-
   const {
     filters,
     searchQuery,
@@ -39,7 +24,6 @@ const BrowseView = () => {
     searchInputValue,
     searchDropdownValue,
   } = useContext(AuthoritiesSearchContext);
-  const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
   const {
     authorities,
@@ -58,41 +42,9 @@ const BrowseView = () => {
     precedingRecordsCount: PRECEDING_RECORDS_COUNT,
   });
 
-  const onSubmitSearch = e => {
-    if (e && e.preventDefault) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-
+  const onSubmitSearch = () => {
     setSearchQuery(searchInputValue);
     setSearchIndex(searchDropdownValue);
-    setSelectedAuthorityRecordContext(null);
-  };
-
-  const renderPaneSub = () => {
-    return (
-      <span>
-        {intl.formatMessage({
-          id: 'stripes-authority-components.search-results-list.paneSub',
-        }, {
-          totalRecords,
-        })}
-      </span>
-    );
-  };
-
-  const renderResultsFirstMenu = () => {
-    if (isFilterPaneVisible) {
-      return null;
-    }
-
-    return (
-      <PaneMenu>
-        <ExpandFilterPaneButton
-          onClick={toggleFilterPane}
-        />
-      </PaneMenu>
-    );
   };
 
   const formattedAuthoritiesForView = useMemo(() => {
@@ -110,42 +62,20 @@ const BrowseView = () => {
   }, [authorities]);
 
   return (
-    <>
-      <AuthoritiesSearchPane
-        isFilterPaneVisible={isFilterPaneVisible}
-        toggleFilterPane={toggleFilterPane}
-        isLoading={isLoading}
-        onSubmitSearch={onSubmitSearch}
-        query={query}
-      />
-      <Pane
-        id="authority-search-results-pane"
-        appIcon={<AppIcon app="marc-authorities" />}
-        defaultWidth="fill"
-        paneTitle={intl.formatMessage({ id: 'stripes-authority-components.meta.title' })}
-        paneSub={renderPaneSub()}
-        firstMenu={renderResultsFirstMenu()}
-        padContent={false}
-        noOverflow
-      >
-        <SearchResultsList
-          authorities={formattedAuthoritiesForView}
-          totalResults={totalRecords}
-          pageSize={PAGE_SIZE}
-          onNeedMoreData={handleLoadMore}
-          loading={isLoading}
-          loaded={isLoaded}
-          visibleColumns={['authRefType', 'headingRef', 'headingType']}
-          isFilterPaneVisible={isFilterPaneVisible}
-          toggleFilterPane={toggleFilterPane}
-          hasFilters={!!filters.length}
-          query={searchQuery}
-          hasNextPage={hasNextPage}
-          hasPrevPage={hasPrevPage}
-          hidePageIndices
-        />
-      </Pane>
-    </>
+    <AuthoritiesLookup
+      authorities={formattedAuthoritiesForView}
+      totalRecords={totalRecords}
+      searchQuery={searchQuery}
+      query={query}
+      isLoaded={isLoaded}
+      isLoading={isLoading}
+      hasFilters={!!filters.length}
+      hasNextPage={hasNextPage}
+      hasPrevPage={hasPrevPage}
+      hidePageIndices
+      onNeedMoreData={handleLoadMore}
+      onSubmitSearch={onSubmitSearch}
+    />
   );
 };
 

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -1,15 +1,16 @@
 import { render } from '@testing-library/react';
 
-import { runAxeTest } from '@folio/stripes-testing';
-
 import BrowseView from './BrowseView';
 
 import Harness from '../../../test/jest/helpers/harness';
+import AuthoritiesLookup from '../../components/AuthoritiesLookup';
 
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
   useAuthorities: () => ({ authorities: [] }),
 }));
+
+jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
 
 const renderBrowseView = (props = {}) => render(
   <Harness>
@@ -22,17 +23,23 @@ describe('Given BrowseView', () => {
     jest.clearAllMocks();
   });
 
-  it('should render with no axe errors', async () => {
-    const { container } = renderBrowseView();
+  it('should have correct props for AuthoritiesLookup', () => {
+    const expectedProps = {
+      authorities: [],
+      hasFilters: false,
+      hasNextPage: false,
+      hasPrevPage: false,
+      hidePageIndices: true,
+      isLoaded: false,
+      isLoading: true,
+      onNeedMoreData: expect.any(Function),
+      onSubmitSearch: expect.any(Function),
+      query: undefined,
+      searchQuery: '',
+      totalRecords: NaN,
+    };
 
-    await runAxeTest({
-      rootNode: container,
-    });
-  });
-
-  it('should display AuthoritiesSearchPane', () => {
-    const { getByTestId } = renderBrowseView();
-
-    expect(getByTestId('pane-authorities-filters')).toBeDefined();
+    renderBrowseView();
+    expect(AuthoritiesLookup).toHaveBeenNthCalledWith(1, expectedProps, {});
   });
 });

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -1,42 +1,27 @@
-import {
-  useState,
-  useContext,
-} from 'react';
-import { useIntl } from 'react-intl';
+import { useContext } from 'react';
 
-import { AppIcon } from '@folio/stripes/core';
 import {
-  Pane,
-  PaneMenu,
-} from '@folio/stripes/components';
-import { ExpandFilterPaneButton } from '@folio/stripes/smart-components';
-import {
-  AuthoritiesSearchPane,
-  SearchResultsList,
   AuthoritiesSearchContext,
-  SelectedAuthorityRecordContext,
   useAuthorities,
+  searchableIndexesValues,
 } from '@folio/stripes-authority-components';
 
+import { AuthoritiesLookup } from '../../components';
 import { PAGE_SIZE } from '../../constants';
 
 const SearchView = () => {
-  const intl = useIntl();
-  const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
-
-  const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
-
   const {
     searchQuery,
     searchIndex,
     filters,
-    advancedSearchRows,
+    advancedSearchRows: advancedSearch,
     setSearchQuery,
     setSearchIndex,
     searchInputValue,
     searchDropdownValue,
+    setAdvancedSearchRows: setAdvancedSearch,
   } = useContext(AuthoritiesSearchContext);
-  const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
+  const isAdvancedSearch = searchIndex === searchableIndexesValues.ADVANCED_SEARCH;
   const {
     authorities,
     isLoading,
@@ -47,87 +32,34 @@ const SearchView = () => {
   } = useAuthorities({
     searchQuery,
     searchIndex,
-    advancedSearch: advancedSearchRows,
-    isAdvancedSearch: false,
+    advancedSearch,
+    isAdvancedSearch,
     filters,
     pageSize: PAGE_SIZE,
   });
 
-  const onSubmitSearch = e => {
-    if (e && e.preventDefault) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-
+  const onSubmitSearch = (e, advancedSearchState) => {
+    setAdvancedSearch(advancedSearchState);
     setSearchQuery(searchInputValue);
     setSearchIndex(searchDropdownValue);
-    setSelectedAuthorityRecordContext(null);
   };
 
   const handleLoadMore = (_pageAmount, offset) => {
     setOffset(offset);
   };
 
-  const renderPaneSub = () => {
-    return (
-      <span>
-        {intl.formatMessage({
-          id: 'ui-plugin-find-authority.search-results-list.paneSub',
-        }, {
-          totalRecords,
-        })}
-      </span>
-    );
-  };
-
-  const renderResultsFirstMenu = () => {
-    if (isFilterPaneVisible) {
-      return null;
-    }
-
-    return (
-      <PaneMenu>
-        <ExpandFilterPaneButton
-          onClick={toggleFilterPane}
-        />
-      </PaneMenu>
-    );
-  };
-
   return (
-    <>
-      <AuthoritiesSearchPane
-        isFilterPaneVisible={isFilterPaneVisible}
-        toggleFilterPane={toggleFilterPane}
-        isLoading={isLoading}
-        onSubmitSearch={onSubmitSearch}
-        query={query}
-      />
-      <Pane
-        id="authority-search-results-pane"
-        appIcon={<AppIcon app="marc-authorities" />}
-        defaultWidth="fill"
-        paneTitle={intl.formatMessage({ id: 'stripes-authority-components.meta.title' })}
-        paneSub={renderPaneSub()}
-        firstMenu={renderResultsFirstMenu()}
-        padContent={false}
-        noOverflow
-      >
-        <SearchResultsList
-          authorities={authorities}
-          totalResults={totalRecords}
-          pageSize={PAGE_SIZE}
-          onNeedMoreData={handleLoadMore}
-          loading={isLoading}
-          loaded={isLoaded}
-          visibleColumns={['authRefType', 'headingRef', 'headingType']}
-          isFilterPaneVisible={isFilterPaneVisible}
-          toggleFilterPane={toggleFilterPane}
-          hasFilters={!!filters.length}
-          query={searchQuery}
-        />
-      </Pane>
-    </>
+    <AuthoritiesLookup
+      authorities={authorities}
+      totalRecords={totalRecords}
+      searchQuery={searchQuery}
+      query={query}
+      isLoaded={isLoaded}
+      isLoading={isLoading}
+      hasFilters={!!filters.length}
+      onNeedMoreData={handleLoadMore}
+      onSubmitSearch={onSubmitSearch}
+    />
   );
 };
 

--- a/src/views/SearchView/SearchView.test.js
+++ b/src/views/SearchView/SearchView.test.js
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 
-import { runAxeTest } from '@folio/stripes-testing';
-
+import AuthoritiesLookup from '../../components/AuthoritiesLookup';
 import SearchView from './SearchView';
 
 import Harness from '../../../test/jest/helpers/harness';
@@ -10,6 +9,8 @@ jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
   useAuthorities: () => ({ authorities: [] }),
 }));
+
+jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
 
 const renderSearchView = (props = {}) => render(
   <Harness>
@@ -22,17 +23,20 @@ describe('Given SearchView', () => {
     jest.clearAllMocks();
   });
 
-  it('should render with no axe errors', async () => {
-    const { container } = renderSearchView();
+  it('should have correct props for AuthoritiesLookup', () => {
+    const expectedProps = {
+      authorities: [],
+      hasFilters: false,
+      isLoaded: undefined,
+      isLoading: undefined,
+      onNeedMoreData: expect.any(Function),
+      onSubmitSearch: expect.any(Function),
+      query: undefined,
+      searchQuery: '',
+      totalRecords: undefined,
+    };
 
-    await runAxeTest({
-      rootNode: container,
-    });
-  });
-
-  it('should display AuthoritiesSearchPane', () => {
-    const { getByTestId } = renderSearchView();
-
-    expect(getByTestId('pane-authorities-filters')).toBeDefined();
+    renderSearchView();
+    expect(AuthoritiesLookup).toHaveBeenNthCalledWith(1, expectedProps, {});
   });
 });

--- a/test/jest/__mock__/reactIntl.mock.js
+++ b/test/jest/__mock__/reactIntl.mock.js
@@ -1,6 +1,7 @@
 jest.mock('react-intl', () => {
   const intl = {
     formatMessage: ({ id }) => id,
+    formatDate: ({ id }) => id,
   };
 
   return {


### PR DESCRIPTION
## Purpose
View a MARC authority detail record.

Also, changes were fulfilled in:
- [ui-quick-marc](https://github.com/folio-org/ui-quick-marc/pull/353)
- [ui-marc-authorities](https://github.com/folio-org/ui-marc-authorities/pull/191)
- [stripes-authority-components](https://github.com/folio-org/stripes-authority-components/pull/14)

## Issues
[UIPFAUTH-5](https://issues.folio.org/browse/UIPFAUTH-5)

## Screencast





https://user-images.githubusercontent.com/77053927/186112089-93a8f3d0-f0c3-4b5f-b6c7-ba657785f8b9.mp4


