### PR TITLE
UIPFAUTH-9: move stripes-authority-components to peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 * Create an empty modal window for find Authorities plugin. Refs UIPFAUTH-7
 * Select a MARC authority record modal > Results list - Search. Refs UIPFAUTH-3
 * Select a MARC authority record modal > Results list - Browse. Refs UIPFAUTH-4
+* move stripes-authority-components to peerDependencies. Refs UIPFAUTH-9

--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
-    "@folio/stripes-authority-components": "^1.0.0",
     "query-string": "^7.0.1"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",
+    "@folio/stripes-authority-components": "^1.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-react": "^7.10.4",
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/stripes": "^7.0.0",
+    "@folio/stripes-authority-components": "^1.0.0",
     "@folio/stripes-cli": "^2.6.0",
     "@folio/stripes-core": "^8.0.0",
     "@folio/stripes-testing": "^4.2.0",


### PR DESCRIPTION
## Purpose

`stripes-authority-components` must be included under `peerDependencies` instead of `dependencies` given that it is provided as a direct-dep by the platform

## Issues
[UIPFAUTH-9](https://issues.folio.org/browse/UIPFAUTH-9)