### PR TITLE
UIPFAUTH-15 Browse: Long heading ref values in results list are not aligned to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [1.0.0] (IN PROGRESS)
 
-* Create an empty modal window for find Authorities plugin. Refs UIPFAUTH-7
-* Select a MARC authority record modal > Results list - Search. Refs UIPFAUTH-3
-* Select a MARC authority record modal > Results list - Browse. Refs UIPFAUTH-4
-* move stripes-authority-components to peerDependencies. Refs UIPFAUTH-9
-* Select a MARC authority record modal > View a MARC authority detail record. Refs UIPFAUTH-5
+* [UIPFAUTH-7](https://issues.folio.org/browse/UIPFAUTH-7) Create an empty modal window for find Authorities plugin
+* [UIPFAUTH-3](https://issues.folio.org/browse/UIPFAUTH-3) Select a MARC authority record modal > Results list - Search
+* [UIPFAUTH-4](https://issues.folio.org/browse/UIPFAUTH-4) Select a MARC authority record modal > Results list - Browse
+* [UIPFAUTH-9](https://issues.folio.org/browse/UIPFAUTH-9) move stripes-authority-components to peerDependencies
+* [UIPFAUTH-5](https://issues.folio.org/browse/UIPFAUTH-5) Select a MARC authority record modal > View a MARC authority detail record
+* [UIPFAUTH-15](https://issues.folio.org/browse/UIPFAUTH-15) Browse: Long heading ref values in results list are not aligned to the left

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.css
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.css
@@ -1,3 +1,4 @@
 .link {
-    composes: root from '~@folio/stripes-components/lib/TextLink/TextLink.css';
+  composes: root from '~@folio/stripes-components/lib/TextLink/TextLink.css';
+  text-align: left;
 }


### PR DESCRIPTION
## Description
Align heading/ref text to the left

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/187695374-fe71bb88-84eb-4840-a462-e158c7d5f4ca.png)

## Issues
[UIPFAUTH-15](https://issues.folio.org/browse/UIPFAUTH-15)