### PR TITLE
UIPFAUTH-19 Hide counters when browsing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 * [UIPFAUTH-9](https://issues.folio.org/browse/UIPFAUTH-9) move stripes-authority-components to peerDependencies
 * [UIPFAUTH-5](https://issues.folio.org/browse/UIPFAUTH-5) Select a MARC authority record modal > View a MARC authority detail record
 * [UIPFAUTH-15](https://issues.folio.org/browse/UIPFAUTH-15) Browse: Long heading ref values in results list are not aligned to the left
+* [UIPFAUTH-19](https://issues.folio.org/browse/UIPFAUTH-19) The counters at Browse authority pane and "Type of heading" facet options don't match

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -15,6 +15,7 @@ import {
   AuthorityShape,
   SearchResultsList,
   SelectedAuthorityRecordContext,
+  navigationSegments,
 } from '@folio/stripes-authority-components';
 
 import MarcAuthorityView from '../MarcAuthorityView';
@@ -58,7 +59,10 @@ const AuthoritiesLookup = ({
   const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
   const [showDetailView, setShowDetailView] = useState(false);
 
-  const { filters } = useContext(AuthoritiesSearchContext);
+  const {
+    filters,
+    navigationSegmentValue,
+  } = useContext(AuthoritiesSearchContext);
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
   const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
@@ -88,6 +92,10 @@ const AuthoritiesLookup = ({
   };
 
   const renderPaneSub = () => {
+    if (navigationSegmentValue === navigationSegments.browse) {
+      return null;
+    }
+
     return (
       <span>
         {intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.paneSub' }, {


### PR DESCRIPTION
## Description
Hide record counter in pane subtitle when Browsing records

## Issues
[UIPFAUTH-19](https://issues.folio.org/browse/UIPFAUTH-19)