### PR TITLE
UIPFAUTH-11: Default search query change to return - authRefType=Authorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 * [UIPFAUTH-9](https://issues.folio.org/browse/UIPFAUTH-9) move stripes-authority-components to peerDependencies
 * [UIPFAUTH-5](https://issues.folio.org/browse/UIPFAUTH-5) Select a MARC authority record modal > View a MARC authority detail record
 * [UIPFAUTH-15](https://issues.folio.org/browse/UIPFAUTH-15) Browse: Long heading ref values in results list are not aligned to the left
+* [UIPFAUTH-11](https://issues.folio.org/browse/UIPFAUTH-11) Default search query change to return - authRefType=Authorized

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -13,6 +13,8 @@ import {
   AuthoritiesSearchContext,
   AuthoritiesSearchPane,
   AuthorityShape,
+  FILTERS,
+  searchResultListColumns,
   SearchResultsList,
   SelectedAuthorityRecordContext,
 } from '@folio/stripes-authority-components';
@@ -35,10 +37,14 @@ const propTypes = {
   isLoading: PropTypes.bool.isRequired,
   onNeedMoreData: PropTypes.func.isRequired,
   onSubmitSearch: PropTypes.func.isRequired,
-  query: PropTypes.string.isRequired,
+  query: PropTypes.string,
   searchQuery: PropTypes.string.isRequired,
   totalRecords: PropTypes.number.isRequired,
 };
+
+const excludedFilters = new Set([
+  FILTERS.REFERENCES,
+]);
 
 const AuthoritiesLookup = ({
   authorities,
@@ -60,6 +66,12 @@ const AuthoritiesLookup = ({
 
   const { filters } = useContext(AuthoritiesSearchContext);
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
+
+  const columnMapping = {
+    [searchResultListColumns.AUTH_REF_TYPE]: intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.authRefType' }),
+    [searchResultListColumns.HEADING_REF]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingRef' }),
+    [searchResultListColumns.HEADING_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingType' }),
+  };
 
   const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
 
@@ -124,6 +136,7 @@ const AuthoritiesLookup = ({
       <SearchResultsList
         authorities={authorities}
         columnWidths={columnWidths}
+        columnMapping={columnMapping}
         totalResults={totalRecords}
         pageSize={PAGE_SIZE}
         onNeedMoreData={onNeedMoreData}
@@ -152,6 +165,8 @@ const AuthoritiesLookup = ({
         onSubmitSearch={handleSubmitSearch}
         query={query}
         height={MAIN_PANE_HEIGHT}
+        excludedSearchFilters={excludedFilters}
+        excludedBrowseFilters={excludedFilters}
         onShowDetailView={setShowDetailView}
       />
       {showDetailView &&
@@ -167,6 +182,7 @@ const AuthoritiesLookup = ({
 AuthoritiesLookup.propTypes = propTypes;
 
 AuthoritiesLookup.defaultProps = {
+  query: '',
   hasNextPage: null,
   hasPrevPage: null,
   hidePageIndices: false,

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -14,6 +14,7 @@ import {
   PAGE_SIZE,
   PRECEDING_RECORDS_COUNT,
 } from '../../constants';
+import { addDefaultFilters } from '../utils';
 
 const BrowseView = () => {
   const {
@@ -37,7 +38,7 @@ const BrowseView = () => {
     query,
     totalRecords,
   } = useAuthoritiesBrowse({
-    filters,
+    filters: addDefaultFilters(searchQuery, filters),
     searchQuery,
     searchIndex,
     pageSize: PAGE_SIZE,

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -9,6 +9,7 @@ import {
 
 import { AuthoritiesLookup } from '../../components';
 import { PAGE_SIZE } from '../../constants';
+import { addDefaultFilters } from '../utils';
 
 const SearchView = () => {
   const {
@@ -36,7 +37,7 @@ const SearchView = () => {
     searchIndex,
     advancedSearch,
     isAdvancedSearch,
-    filters,
+    filters: addDefaultFilters(searchQuery, filters),
     pageSize: PAGE_SIZE,
   });
 

--- a/src/views/SearchView/SearchView.test.js
+++ b/src/views/SearchView/SearchView.test.js
@@ -1,19 +1,32 @@
 import { render } from '@testing-library/react';
 
+import { useAuthorities } from '@folio/stripes-authority-components';
 import AuthoritiesLookup from '../../components/AuthoritiesLookup';
 import SearchView from './SearchView';
 
 import Harness from '../../../test/jest/helpers/harness';
 
+
+const mockUseAuthorities = {
+  authorities: [],
+  isLoading: false,
+  isLoaded: true,
+  totalRecords: 0,
+  setOffset: 0,
+  query: '',
+};
+
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
-  useAuthorities: () => ({ authorities: [] }),
+  useAuthorities: jest.fn(() => mockUseAuthorities),
 }));
 
 jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
 
-const renderSearchView = (props = {}) => render(
-  <Harness>
+const renderSearchView = (props = {}, authoritiesCtxValue) => render(
+  <Harness
+    authoritiesCtxValue={authoritiesCtxValue}
+  >
     <SearchView {...props} />
   </Harness>,
 );
@@ -27,16 +40,64 @@ describe('Given SearchView', () => {
     const expectedProps = {
       authorities: [],
       hasFilters: false,
-      isLoaded: undefined,
-      isLoading: undefined,
+      isLoaded: true,
+      isLoading: false,
       onNeedMoreData: expect.any(Function),
       onSubmitSearch: expect.any(Function),
-      query: undefined,
+      query: '',
       searchQuery: '',
-      totalRecords: undefined,
+      totalRecords: 0,
     };
 
     renderSearchView();
     expect(AuthoritiesLookup).toHaveBeenNthCalledWith(1, expectedProps, {});
+  });
+
+  describe('when there is no search query and selected filters', () => {
+    it('should not add the complementary filter to retrieve only Authorized records', () => {
+      const authoritiesCtxValue = {
+        searchQuery: '',
+        filters: {},
+      };
+
+      renderSearchView(null, authoritiesCtxValue);
+      expect(useAuthorities).toHaveBeenLastCalledWith(expect.objectContaining({ filters: {} }));
+    });
+  });
+
+  describe('when there is search query', () => {
+    it('should add the complementary filter to retrieve only Authorized records', () => {
+      const authoritiesCtxValue = {
+        searchQuery: 'foo',
+        filters: {},
+      };
+      const expectedFilters = {
+        filters: {
+          references: ['excludeSeeFrom', 'excludeSeeFromAlso'],
+        },
+      };
+
+      renderSearchView(null, authoritiesCtxValue);
+      expect(useAuthorities).toHaveBeenLastCalledWith(expect.objectContaining(expectedFilters));
+    });
+  });
+
+  describe('when there is a selected filter', () => {
+    it('should add the complementary filter to retrieve only Authorized records', () => {
+      const authoritiesCtxValue = {
+        filters: {
+          headingType: ['Topical'],
+        },
+      };
+      const expectedFilters = {
+        filters: {
+          ...authoritiesCtxValue.filters,
+          references: ['excludeSeeFrom', 'excludeSeeFromAlso'],
+        },
+      };
+
+      renderSearchView(null, authoritiesCtxValue);
+      expect(useAuthorities).toHaveBeenLastCalledWith(expect.objectContaining(expectedFilters));
+    });
   });
 });

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -1,0 +1,13 @@
+import isEmpty from 'lodash/isEmpty';
+
+export const addDefaultFilters = (searchQuery, filters) => {
+  const shouldBeRequest = searchQuery || !isEmpty(filters);
+  const defaultFilters = {
+    references: ['excludeSeeFrom', 'excludeSeeFromAlso'],
+  };
+
+  return {
+    ...filters,
+    ...shouldBeRequest && defaultFilters,
+  };
+};

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -1,9 +1,17 @@
 import isEmpty from 'lodash/isEmpty';
 
+import {
+  FILTERS,
+  REFERENCES_VALUES_MAP,
+} from '@folio/stripes-authority-components';
+
 export const addDefaultFilters = (searchQuery, filters) => {
   const shouldBeRequest = searchQuery || !isEmpty(filters);
   const defaultFilters = {
-    references: ['excludeSeeFrom', 'excludeSeeFromAlso'],
+    [FILTERS.REFERENCES]: [
+      REFERENCES_VALUES_MAP.excludeSeeFrom,
+      REFERENCES_VALUES_MAP.excludeSeeFromAlso,
+    ],
   };
 
   return {

--- a/translations/ui-plugin-find-authority/en.json
+++ b/translations/ui-plugin-find-authority/en.json
@@ -2,5 +2,6 @@
   "meta.title": "Authority finder (plugin)",
   "linkToMarcAuthorityRecord": "Link to MARC authority record",
   "modal.title": "Select MARC authority",
-  "search-results-list.paneSub": "{totalRecords, number} {totalRecords, plural, one {result found} other {results found}}"
+  "search-results-list.paneSub": "{totalRecords, number} {totalRecords, plural, one {result found} other {results found}}",
+  "search-results-list.authRefType": "Authorized"
 }


### PR DESCRIPTION
## Purpose
- in the plugin retrieve only `Authorized` records for lookup types `Search` and `Browse`;
- in the plugin change the column name `Authorized/Reference` to `Authorized`;
- remove the `References` filter on the `Search`/`Browse` toggles.

## Approach
Add a `references: ['excludeSeeFrom', 'excludeSeeFromAlso']` filter to request when the user selects/changes a filter or enters a search query to get only `Authorized` records.

## Issues
[UIPFAUTH-11](https://issues.folio.org/browse/UIPFAUTH-11)
[UISAUTCOMP-12](https://issues.folio.org/browse/UISAUTCOMP-12) - cloned

## Screencast




https://user-images.githubusercontent.com/77053927/188610786-737ce0cc-134e-4075-b904-a73a9defd9fd.mp4


