### PR TITLE
UIPFAUTH-16: Add the Expand the Search & filter pane option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 * [UIPFAUTH-15](https://issues.folio.org/browse/UIPFAUTH-15) Browse: Long heading ref values in results list are not aligned to the left
 * [UIPFAUTH-11](https://issues.folio.org/browse/UIPFAUTH-11) Default search query change to return - authRefType=Authorized
 * [UIPFAUTH-19](https://issues.folio.org/browse/UIPFAUTH-19) The counters at Browse authority pane and "Type of heading" facet options don't match
+* [UIPFAUTH-16](https://issues.folio.org/browse/UIPFAUTH-16) Add the Expand the Search & filter pane option

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.css
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.css
@@ -1,15 +1,3 @@
-.hidden {
-  display: none;
-}
-
-.pane {
-  composes: pane from "~@folio/stripes-components/lib/Pane/Pane.css";
-}
-
-.focusIndicator {
-  composes: focusWithinIndicator from "~@folio/stripes-components/lib/sharedStyles/focusWithinIndicator.css";
-}
-
 .link {
   composes: root from '~@folio/stripes-components/lib/TextLink/TextLink.css';
   text-align: left;

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -7,8 +7,12 @@ import { useIntl } from 'react-intl';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import { Pane } from '@folio/stripes/components';
+import {
+  Pane,
+  PaneMenu,
+} from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
+import { ExpandFilterPaneButton } from '@folio/stripes/smart-components';
 import {
   AuthoritiesSearchContext,
   AuthoritiesSearchPane,
@@ -18,6 +22,7 @@ import {
   SearchResultsList,
   SelectedAuthorityRecordContext,
   navigationSegments,
+  useAutoOpenDetailView,
 } from '@folio/stripes-authority-components';
 
 import MarcAuthorityView from '../MarcAuthorityView';
@@ -64,6 +69,7 @@ const AuthoritiesLookup = ({
   const intl = useIntl();
   const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
   const [showDetailView, setShowDetailView] = useState(false);
+  const [itemToView, setItemToView] = useState(null);
 
   const {
     filters,
@@ -88,6 +94,13 @@ const AuthoritiesLookup = ({
     setShowDetailView(true);
   };
 
+  const handleRowFocus = ({ selector, localClientTop }) => {
+    setItemToView({
+      selector,
+      localClientTop,
+    });
+  };
+
   useEffect(() => {
     closeDetailView();
     // eslint-disable-next-line
@@ -103,6 +116,8 @@ const AuthoritiesLookup = ({
     onSubmitSearch(e, ...rest);
   };
 
+  useAutoOpenDetailView(authorities, openDetailView);
+
   const renderPaneSub = () => {
     if (navigationSegmentValue === navigationSegments.browse) {
       return null;
@@ -114,6 +129,20 @@ const AuthoritiesLookup = ({
           totalRecords,
         })}
       </span>
+    );
+  };
+
+  const renderResultsFirstMenu = () => {
+    if (isFilterPaneVisible) {
+      return null;
+    }
+
+    return (
+      <PaneMenu>
+        <ExpandFilterPaneButton
+          onClick={toggleFilterPane}
+        />
+      </PaneMenu>
     );
   };
 
@@ -131,12 +160,12 @@ const AuthoritiesLookup = ({
   const renderResultList = () => (
     <Pane
       id="authority-search-results-pane"
-      className={classNames(css.pane, css.focusIndicator, { [css.hidden]: showDetailView })}
       data-testid="authority-search-results-pane"
       appIcon={<AppIcon app="marc-authorities" />}
       defaultWidth="fill"
       paneTitle={intl.formatMessage({ id: 'stripes-authority-components.meta.title' })}
       paneSub={renderPaneSub()}
+      firstMenu={renderResultsFirstMenu()}
       padContent={false}
       noOverflow
       height={MAIN_PANE_HEIGHT}
@@ -159,7 +188,8 @@ const AuthoritiesLookup = ({
         hasPrevPage={hasPrevPage}
         hidePageIndices={hidePageIndices}
         renderHeadingRef={renderHeadingRef}
-        onOpenRecord={openDetailView}
+        itemToView={itemToView}
+        onHandleRowFocus={handleRowFocus}
       />
     </Pane>
   );
@@ -177,12 +207,14 @@ const AuthoritiesLookup = ({
         excludedBrowseFilters={excludedFilters}
         onShowDetailView={setShowDetailView}
       />
-      {showDetailView &&
-        <MarcAuthorityView
-          onCloseDetailView={closeDetailView}
-        />
+      {showDetailView
+        ? (
+          <MarcAuthorityView
+            onCloseDetailView={closeDetailView}
+          />
+        )
+        : renderResultList()
       }
-      {renderResultList()}
     </>
   );
 };

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -189,7 +189,7 @@ const AuthoritiesLookup = ({
         hidePageIndices={hidePageIndices}
         renderHeadingRef={renderHeadingRef}
         itemToView={itemToView}
-        onHandleRowFocus={handleRowFocus}
+        onRowFocus={handleRowFocus}
       />
     </Pane>
   );

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -89,7 +89,7 @@ describe('Given AuthoritiesLookup', () => {
       expect(MultiColumnList).toHaveBeenLastCalledWith(expect.objectContaining({
         itemToView: {
           selector: 'any',
-          localClientTop: 123,
+          localClientTop: 123, // can be found in stripesComponents.mock.js file
         },
       }), {});
     });

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
 import authorities from '@folio/stripes-authority-components/mocks/authorities.json'; // eslint-disable-line import/extensions
+import { MultiColumnList } from '@folio/stripes/components';
 
 import AuthoritiesLookup from './AuthoritiesLookup';
 
@@ -76,35 +77,38 @@ describe('Given AuthoritiesLookup', () => {
       fireEvent.click(linkStyleBtnOfRow);
     });
 
-    it('should hide the list of items (not unmount)', () => {
-      expect(screen.getByTestId('authority-search-results-pane')).toHaveAttribute('class', 'pane focusIndicator hidden');
+    it('should hide the list of items', () => {
+      expect(screen.queryByTestId('authority-search-results-pane')).not.toBeInTheDocument();
     });
 
     it('should open the detail view', () => {
       expect(screen.getByTestId('marc-view-pane')).toBeVisible();
     });
+
+    it('should pass correct data about the position of the selected list item', () => {
+      expect(MultiColumnList).toHaveBeenLastCalledWith(expect.objectContaining({
+        itemToView: {
+          selector: 'any',
+          localClientTop: 123,
+        },
+      }), {});
+    });
   });
 
   describe('when there is only one record', () => {
     beforeEach(() => {
-      const { getByTestId } = renderAuthoritiesSearchPane({
+      renderAuthoritiesSearchPane({
         authorities: [authorities[0]],
         totalRecords: 1,
       });
-      const searchField = getByTestId('search-textarea');
-
-      fireEvent.change(searchField, { target: { value: 'foo' } });
-      fireEvent.click(getByTestId('submit-authorities-search'));
     });
 
-    it('should hide the list of results', () => {
-      waitFor(() => {
-        expect(screen.getByTestId('authority-search-results-pane')).toHaveAttribute('class', 'pane focusIndicator hidden');
-      });
+    it('should hide the list of items', () => {
+      expect(screen.queryByTestId('authority-search-results-pane')).not.toBeInTheDocument();
     });
 
     it('should open the detail view', () => {
-      waitFor(() => { expect(screen.getByTestId('marc-view-pane')).toBeVisible(); });
+      expect(screen.getByTestId('marc-view-pane')).toBeVisible();
     });
   });
 
@@ -122,7 +126,7 @@ describe('Given AuthoritiesLookup', () => {
     });
 
     it('should show the list of results', () => {
-      expect(screen.getByTestId('authority-search-results-pane')).toHaveAttribute('class', 'pane focusIndicator');
+      expect(screen.getByTestId('authority-search-results-pane')).toBeVisible();
     });
 
     it('should invoke onSubmitSearch cb', () => {

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -1,4 +1,7 @@
-import { useContext } from 'react';
+import {
+  useContext,
+  useMemo,
+} from 'react';
 
 import {
   AuthoritiesSearchContext,
@@ -25,6 +28,7 @@ const SearchView = () => {
   } = useContext(AuthoritiesSearchContext);
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
   const isAdvancedSearch = searchIndex === searchableIndexesValues.ADVANCED_SEARCH;
+  const updatedFilters = useMemo(() => addDefaultFilters(searchQuery, filters), [searchQuery, filters]);
   const {
     authorities,
     isLoading,
@@ -37,7 +41,7 @@ const SearchView = () => {
     searchIndex,
     advancedSearch,
     isAdvancedSearch,
-    filters: addDefaultFilters(searchQuery, filters),
+    filters: updatedFilters,
     pageSize: PAGE_SIZE,
   });
 

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -8,10 +8,21 @@ jest.mock('@folio/stripes/components', () => ({
     contentData,
     formatter,
     onRowClick,
+    onMarkPosition,
   }) => {
     if (isEmptyMessage && !totalCount) {
       return isEmptyMessage;
     }
+
+    const handleRowClick = (e, item) => {
+      if (onMarkPosition) {
+        onMarkPosition({
+          selector: 'any',
+          localClientTop: 123,
+        });
+      }
+      onRowClick(e, item);
+    };
 
     const tableHeader = visibleColumns.map((columnName, index) => (
       <td key={index}>{columnMapping[columnName]}</td>
@@ -23,7 +34,7 @@ jest.mock('@folio/stripes/components', () => ({
           <td>
             <button
               type="button"
-              onClick={e => onRowClick(e, item)}
+              onClick={e => handleRowClick(e, item)}
             >
 
               row button


### PR DESCRIPTION
## Purpose
- add the `Expand the Search & filter pane` option to the results list;
- fix the [missing pagination buttons](https://user-images.githubusercontent.com/77053927/189202865-932f9932-db7c-4a3a-b090-bfdfacab6f72.mp4) ;
- keep the focus on the last selected list item after closing the detail view;
- fix offset by clicking on pagination (previously reset to 0).

## Issues
[UIPFAUTH-16](https://issues.folio.org/browse/UIPFAUTH-16)
[UIMARCAUTH-182](https://issues.folio.org/browse/UIMARCAUTH-182)
[UISAUTCOMP-14](https://issues.folio.org/browse/UISAUTCOMP-14)

## Screencast





https://user-images.githubusercontent.com/77053927/189209460-f2f6dd4d-07c7-4c92-9862-0e3ec691baad.mp4


