### PR TITLE
UIPFAUTH-14 Detail Record : Click Link button to select a MARC authority record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 * [UIPFAUTH-15](https://issues.folio.org/browse/UIPFAUTH-15) Browse: Long heading ref values in results list are not aligned to the left
 * [UIPFAUTH-11](https://issues.folio.org/browse/UIPFAUTH-11) Default search query change to return - authRefType=Authorized
 * [UIPFAUTH-19](https://issues.folio.org/browse/UIPFAUTH-19) The counters at Browse authority pane and "Type of heading" facet options don't match
+* [UIPFAUTH-14](https://issues.folio.org/browse/UIPFAUTH-14) Detail Record : Click Link button to select a MARC authority record

--- a/src/FindAuthority.js
+++ b/src/FindAuthority.js
@@ -11,6 +11,7 @@ import {
 import { SearchModal } from './components';
 
 const propTypes = {
+  onLinkRecord: PropTypes.func.isRequired,
   renderCustomTrigger: PropTypes.func,
 };
 
@@ -20,6 +21,7 @@ const defaultProps = {
 
 const FindAuthority = ({
   renderCustomTrigger,
+  onLinkRecord,
 }) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState(false);
@@ -44,6 +46,11 @@ const FindAuthority = ({
     );
   };
 
+  const handleLinkAuthority = record => {
+    onLinkRecord(record);
+    closeModal();
+  };
+
   const renderTrigger = () => {
     return renderCustomTrigger
       ? renderCustomTrigger({ onClick: openModal })
@@ -58,6 +65,7 @@ const FindAuthority = ({
           <SearchModal
             open={isOpen}
             onClose={closeModal}
+            onLinkRecord={handleLinkAuthority}
           />
         </SelectedAuthorityRecordContextProvider>
       </AuthoritiesSearchContextProvider>

--- a/src/FindAuthority.test.js
+++ b/src/FindAuthority.test.js
@@ -12,8 +12,11 @@ jest.mock('./components', () => ({
   SearchModal: jest.fn(() => <div>SearchModal</div>),
 }));
 
+const mockOnLinkRecord = jest.fn();
+
 const renderFindAuthority = (props = {}) => render(
   <FindAuthority
+    onLinkRecord={mockOnLinkRecord}
     {...props}
   />,
 );

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -36,6 +36,7 @@ const propTypes = {
   hidePageIndices: PropTypes.bool,
   isLoaded: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  onLinkRecord: PropTypes.func.isRequired,
   onNeedMoreData: PropTypes.func.isRequired,
   onSubmitSearch: PropTypes.func.isRequired,
   query: PropTypes.string,
@@ -60,6 +61,7 @@ const AuthoritiesLookup = ({
   hidePageIndices,
   onNeedMoreData,
   onSubmitSearch,
+  onLinkRecord,
 }) => {
   const intl = useIntl();
   const [isFilterPaneVisible, setIsFilterPaneVisible] = useState(true);
@@ -180,6 +182,7 @@ const AuthoritiesLookup = ({
       {showDetailView &&
         <MarcAuthorityView
           onCloseDetailView={closeDetailView}
+          onLinkRecord={onLinkRecord}
         />
       }
       {renderResultList()}

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -29,6 +29,7 @@ jest.mock('@folio/stripes-authority-components', () => ({
 
 const mockAuthorities = authorities.slice(0, 2);
 const mockOnSubmitSearch = jest.fn();
+const mockOnLinkRecord = jest.fn();
 
 const getAuthoritiesSearchPane = (props = {}) => (
   <Harness>
@@ -42,6 +43,7 @@ const getAuthoritiesSearchPane = (props = {}) => (
       totalRecords={mockAuthorities.length}
       onNeedMoreData={jest.fn()}
       onSubmitSearch={mockOnSubmitSearch}
+      onLinkRecord={mockOnLinkRecord}
       {...props}
     />
   </Harness>

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -1,9 +1,12 @@
 import { useContext } from 'react';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useQueryClient } from 'react-query';
 import PropTypes from 'prop-types';
 
-import { Loading } from '@folio/stripes/components';
+import {
+  Button,
+  Loading,
+} from '@folio/stripes/components';
 import {
   useMarcSource,
   useAuthority,
@@ -21,17 +24,19 @@ import { MAIN_PANE_HEIGHT } from '../../constants';
 
 const propTypes = {
   onCloseDetailView: PropTypes.func.isRequired,
+  onLinkRecord: PropTypes.func.isRequired,
 };
 
 const MarcAuthorityView = ({
   onCloseDetailView,
+  onLinkRecord,
 }) => {
   const queryClient = useQueryClient();
   const authoritySourceNamespace = useNamespace({ key: QUERY_KEY_AUTHORITY_SOURCE });
   const callout = useCallout();
   const intl = useIntl();
-  const [selectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
-  const { id, authRefType, headingRef } = selectedAuthorityRecordContext;
+  const [selectedAuthorityRecord] = useContext(SelectedAuthorityRecordContext);
+  const { id, authRefType, headingRef } = selectedAuthorityRecord;
 
   const handleAuthorityLoadError = async err => {
     const errorResponse = await err.response;
@@ -74,6 +79,15 @@ const MarcAuthorityView = ({
       marcTitle={intl.formatMessage({ id: 'stripes-authority-components.marcHeading' })}
       marc={markHighlightedFields(marcSource, authority).data}
       onClose={onCloseDetailView}
+      lastMenu={(
+        <Button
+          buttonStyle="primary"
+          marginBottom0
+          onClick={() => onLinkRecord(selectedAuthorityRecord)}
+        >
+          <FormattedMessage id="ui-plugin-find-authority.button.link" />
+        </Button>
+      )}
     />
   );
 };

--- a/src/components/MarcAuthorityView/MarcAuthorityView.test.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
 import authorities from '@folio/stripes-authority-components/mocks/authorities.json'; // eslint-disable-line import/extensions
@@ -12,6 +12,7 @@ import MarcAuthorityView from './MarcAuthorityView';
 import Harness from '../../../test/jest/helpers/harness';
 
 const mockSendCallout = jest.fn();
+const mockOnLinkRecord = jest.fn();
 
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
@@ -96,6 +97,7 @@ const getMarcAuthorityView = (props = {}, selectedRecord = authorities[0]) => (
   <Harness selectedRecordCtxValue={[selectedRecord, mockSetSelectedAuthorityRecordContext]}>
     <MarcAuthorityView
       onCloseDetailView={jest.fn()}
+      onLinkRecord={mockOnLinkRecord}
       {...props}
     />
   </Harness>
@@ -113,6 +115,22 @@ describe('Given MarcAuthorityView', () => {
 
     await runAxeTest({
       rootNode: container,
+    });
+  });
+
+  it('should render link authority button', () => {
+    const { getByText } = renderMarcAuthorityView();
+
+    expect(getByText('ui-plugin-find-authority.button.link')).toBeDefined();
+  });
+
+  describe('when clicking on Link authority', () => {
+    it('should call onLinkRecord with autority record', () => {
+      const { getByText } = renderMarcAuthorityView();
+
+      fireEvent.click(getByText('ui-plugin-find-authority.button.link'));
+
+      expect(mockOnLinkRecord).toHaveBeenCalledWith(authorities[0]);
     });
   });
 

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -18,12 +18,14 @@ import css from './SearchModal.css';
 
 const propTypes = {
   onClose: PropTypes.func.isRequired,
+  onLinkRecord: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
 };
 
 const SearchModal = ({
   open,
   onClose,
+  onLinkRecord,
 }) => {
   const { navigationSegmentValue } = useContext(AuthoritiesSearchContext);
 
@@ -45,8 +47,8 @@ const SearchModal = ({
       >
         {
           navigationSegmentValue === navigationSegments.search
-            ? <SearchView />
-            : <BrowseView />
+            ? <SearchView onLinkRecord={onLinkRecord} />
+            : <BrowseView onLinkRecord={onLinkRecord} />
         }
       </PersistedPaneset>
     </Modal>

--- a/src/components/SearchModal/SearchModal.test.js
+++ b/src/components/SearchModal/SearchModal.test.js
@@ -13,19 +13,18 @@ jest.mock('../../views', () => ({
   BrowseView: () => <div>BrowseView</div>,
 }));
 
-const requiredProps = {
-  open: true,
-  onClose: jest.fn(),
-};
-
 const defaultCtxValue = {
   navigationSegmentValue: navigationSegments.search,
 };
 
+const mockOnLinkRecord = jest.fn();
+
 const renderSearchModal = (props = {}, ctxValue = defaultCtxValue) => render(
   <Harness authoritiesCtxValue={ctxValue}>
     <SearchModal
-      {...requiredProps}
+      open
+      onClose={jest.fn()}
+      onLinkRecord={mockOnLinkRecord}
       {...props}
     />
   </Harness>,

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -2,6 +2,7 @@ import {
   useContext,
   useMemo,
 } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   AuthoritiesSearchContext,
@@ -16,7 +17,11 @@ import {
 } from '../../constants';
 import { addDefaultFilters } from '../utils';
 
-const BrowseView = () => {
+const propTypes = {
+  onLinkRecord: PropTypes.func.isRequired,
+};
+
+const BrowseView = ({ onLinkRecord }) => {
   const {
     filters,
     searchQuery,
@@ -79,8 +84,11 @@ const BrowseView = () => {
       hidePageIndices
       onNeedMoreData={handleLoadMore}
       onSubmitSearch={onSubmitSearch}
+      onLinkRecord={onLinkRecord}
     />
   );
 };
+
+BrowseView.propTypes = propTypes;
 
 export default BrowseView;

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -12,9 +12,14 @@ jest.mock('@folio/stripes-authority-components', () => ({
 
 jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
 
+const mockOnLinkRecord = jest.fn();
+
 const renderBrowseView = (props = {}) => render(
   <Harness>
-    <BrowseView {...props} />
+    <BrowseView
+      onLinkRecord={mockOnLinkRecord}
+      {...props}
+    />
   </Harness>,
 );
 
@@ -34,6 +39,7 @@ describe('Given BrowseView', () => {
       isLoading: true,
       onNeedMoreData: expect.any(Function),
       onSubmitSearch: expect.any(Function),
+      onLinkRecord: mockOnLinkRecord,
       query: undefined,
       searchQuery: '',
       totalRecords: NaN,

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   AuthoritiesSearchContext,
@@ -11,7 +12,11 @@ import { AuthoritiesLookup } from '../../components';
 import { PAGE_SIZE } from '../../constants';
 import { addDefaultFilters } from '../utils';
 
-const SearchView = () => {
+const propTypes = {
+  onLinkRecord: PropTypes.func.isRequired,
+};
+
+const SearchView = ({ onLinkRecord }) => {
   const {
     searchQuery,
     searchIndex,
@@ -63,8 +68,11 @@ const SearchView = () => {
       hasFilters={!!filters.length}
       onNeedMoreData={handleLoadMore}
       onSubmitSearch={onSubmitSearch}
+      onLinkRecord={onLinkRecord}
     />
   );
 };
+
+SearchView.propTypes = propTypes;
 
 export default SearchView;

--- a/src/views/SearchView/SearchView.test.js
+++ b/src/views/SearchView/SearchView.test.js
@@ -23,11 +23,16 @@ jest.mock('@folio/stripes-authority-components', () => ({
 
 jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
 
+const mockOnLinkRecord = jest.fn();
+
 const renderSearchView = (props = {}, authoritiesCtxValue) => render(
   <Harness
     authoritiesCtxValue={authoritiesCtxValue}
   >
-    <SearchView {...props} />
+    <SearchView
+      onLinkRecord={mockOnLinkRecord}
+      {...props}
+    />
   </Harness>,
 );
 
@@ -44,6 +49,7 @@ describe('Given SearchView', () => {
       isLoading: false,
       onNeedMoreData: expect.any(Function),
       onSubmitSearch: expect.any(Function),
+      onLinkRecord: mockOnLinkRecord,
       query: '',
       searchQuery: '',
       totalRecords: 0,

--- a/translations/ui-plugin-find-authority/en.json
+++ b/translations/ui-plugin-find-authority/en.json
@@ -3,5 +3,6 @@
   "linkToMarcAuthorityRecord": "Link to MARC authority record",
   "modal.title": "Select MARC authority",
   "search-results-list.paneSub": "{totalRecords, number} {totalRecords, plural, one {result found} other {results found}}",
-  "search-results-list.authRefType": "Authorized"
+  "search-results-list.authRefType": "Authorized",
+  "button.link": "Link"
 }


### PR DESCRIPTION
## Description
Handle linking of Authority record via details pane header

## Screenshots

https://user-images.githubusercontent.com/19309423/189623469-b4b774f0-b3d0-418b-8a69-d17f073d956c.mp4


## Issues
[UIPFAUTH-14](https://issues.folio.org/browse/UIPFAUTH-14)

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/367