### PR TITLE
UIPFAUTH-13 Results List : Click Link icon/button to select a MARC authority record

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,7 +59,7 @@
     }],
     "react/hook-use-state": "error",
     "react/no-array-index-key": "error",
-    "react/no-multi-comp": "error",
+    "react/no-multi-comp": "off",
     "react/require-default-props": "error",
     "react/jsx-key": "error",
     "react/jsx-max-props-per-line": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 * [UIPFAUTH-19](https://issues.folio.org/browse/UIPFAUTH-19) The counters at Browse authority pane and "Type of heading" facet options don't match
 * [UIPFAUTH-16](https://issues.folio.org/browse/UIPFAUTH-16) Add the Expand the Search & filter pane option
 * [UIPFAUTH-14](https://issues.folio.org/browse/UIPFAUTH-14) Detail Record : Click Link button to select a MARC authority record
+* [UIPFAUTH-13](https://issues.folio.org/browse/UIPFAUTH-13) Results List : Click Link icon/button to select a MARC authority record

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import {
   Pane,
   PaneMenu,
+  IconButton,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 import { ExpandFilterPaneButton } from '@folio/stripes/smart-components';
@@ -80,10 +81,31 @@ const AuthoritiesLookup = ({
   const [, setSelectedAuthorityRecordContext] = useContext(SelectedAuthorityRecordContext);
 
   const columnMapping = {
+    [searchResultListColumns.LINK]: intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' }),
     [searchResultListColumns.AUTH_REF_TYPE]: intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.authRefType' }),
     [searchResultListColumns.HEADING_REF]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingRef' }),
     [searchResultListColumns.HEADING_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingType' }),
   };
+
+  const formatter = {
+    [searchResultListColumns.LINK]: authority => (
+      <IconButton
+        data-testid="link-authority-button"
+        icon="link"
+        aria-haspopup="true"
+        title={intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' })}
+        ariaLabel={intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' })}
+        onClick={() => onLinkRecord(authority)}
+      />
+    ),
+  };
+
+  const visibleColumns = [
+    searchResultListColumns.LINK,
+    searchResultListColumns.AUTH_REF_TYPE,
+    searchResultListColumns.HEADING_REF,
+    searchResultListColumns.HEADING_TYPE,
+  ];
 
   const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);
 
@@ -176,12 +198,13 @@ const AuthoritiesLookup = ({
         authorities={authorities}
         columnWidths={columnWidths}
         columnMapping={columnMapping}
+        formatter={formatter}
         totalResults={totalRecords}
         pageSize={PAGE_SIZE}
         onNeedMoreData={onNeedMoreData}
         loading={isLoading}
         loaded={isLoaded}
-        visibleColumns={['authRefType', 'headingRef', 'headingType']}
+        visibleColumns={visibleColumns}
         isFilterPaneVisible={isFilterPaneVisible}
         toggleFilterPane={toggleFilterPane}
         hasFilters={hasFilters}

--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -2,6 +2,7 @@ import { searchResultListColumns } from '@folio/stripes-authority-components';
 
 export const MAIN_PANE_HEIGHT = '609px';
 export const columnWidths = {
+  [searchResultListColumns.LINK]: { min: 45, max: 45 },
   [searchResultListColumns.SELECT]: { min: 30, max: 30 },
   [searchResultListColumns.AUTH_REF_TYPE]: { min: 155, max: 166 },
   [searchResultListColumns.HEADING_REF]: { min: 390, max: 435 },

--- a/translations/ui-plugin-find-authority/en.json
+++ b/translations/ui-plugin-find-authority/en.json
@@ -4,5 +4,6 @@
   "modal.title": "Select MARC authority",
   "search-results-list.paneSub": "{totalRecords, number} {totalRecords, plural, one {result found} other {results found}}",
   "search-results-list.authRefType": "Authorized",
+  "search-results-list.link": "Link",
   "button.link": "Link"
 }


### PR DESCRIPTION
## Description
Show `Link` column in the plugin

## Screenshots
https://user-images.githubusercontent.com/19309423/189883993-78b767a8-d31c-4813-8f36-61ac1b23d988.mp4

## Issues
[UIPFAUTH-13](https://issues.folio.org/browse/UIPFAUTH-13)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/199
https://github.com/folio-org/stripes-authority-components/pull/24