### PR TITLE
UIPFAUTH-26: The pane size of the "Search & filter" pane changes when user changes scale of the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 * [UIPFAUTH-14](https://issues.folio.org/browse/UIPFAUTH-14) Detail Record : Click Link button to select a MARC authority record
 * [UIPFAUTH-13](https://issues.folio.org/browse/UIPFAUTH-13) Results List : Click Link icon/button to select a MARC authority record
 * [UIPFAUTH-21](https://issues.folio.org/browse/UIPFAUTH-21) The error "Something went wrong" appears when search by same search option and updated query
+* [UIPFAUTH-26](https://issues.folio.org/browse/UIPFAUTH-26) The pane size of the "Search & filter" pane changes when user changes scale of the screen

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -72,6 +72,7 @@ const MarcAuthorityView = ({
 
   return (
     <MarcView
+      isPaneset={false}
       paneWidth="fill"
       paneHeight={MAIN_PANE_HEIGHT}
       paneTitle={authority.data.headingRef}


### PR DESCRIPTION
## Purpose
The `Search & filter` pane should not be the full width of the modal after the browser window is scaled.
## Issue
[UIPFAUTH-26](https://issues.folio.org/browse/UIPFAUTH-26)
Also, this is a fix for [UIPFAUTH-27](https://issues.folio.org/browse/UIPFAUTH-27)

## Screencast





https://user-images.githubusercontent.com/77053927/191267103-250dece1-e8b4-4a03-899e-a2d3f4b2e299.mp4




