### PR TITLE
UIPFAUTH-28: remove the link action on a placeholder row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 * [UIPFAUTH-13](https://issues.folio.org/browse/UIPFAUTH-13) Results List : Click Link icon/button to select a MARC authority record
 * [UIPFAUTH-21](https://issues.folio.org/browse/UIPFAUTH-21) The error "Something went wrong" appears when search by same search option and updated query
 * [UIPFAUTH-26](https://issues.folio.org/browse/UIPFAUTH-26) The pane size of the "Search & filter" pane changes when user changes scale of the screen
+* [UIPFATH-28](https://issues.folio.org/browse/UIPFAUTH-28) Browse: Remove the link action on a placeholder row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,4 @@
 * [UIPFAUTH-13](https://issues.folio.org/browse/UIPFAUTH-13) Results List : Click Link icon/button to select a MARC authority record
 * [UIPFAUTH-21](https://issues.folio.org/browse/UIPFAUTH-21) The error "Something went wrong" appears when search by same search option and updated query
 * [UIPFAUTH-26](https://issues.folio.org/browse/UIPFAUTH-26) The pane size of the "Search & filter" pane changes when user changes scale of the screen
-* [UIPFATH-28](https://issues.folio.org/browse/UIPFAUTH-28) Browse: Remove the link action on a placeholder row
+* [UIPFAUTH-28](https://issues.folio.org/browse/UIPFAUTH-28) Browse: Remove the link action on a placeholder row

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -88,16 +88,22 @@ const AuthoritiesLookup = ({
   };
 
   const formatter = {
-    [searchResultListColumns.LINK]: authority => (
-      <IconButton
-        data-testid="link-authority-button"
-        icon="link"
-        aria-haspopup="true"
-        title={intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' })}
-        ariaLabel={intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' })}
-        onClick={() => onLinkRecord(authority)}
-      />
-    ),
+    [searchResultListColumns.LINK]: authority => {
+      const { id } = authority;
+
+      if (!id) return null;
+
+      return (
+        <IconButton
+          data-testid="link-authority-button"
+          icon="link"
+          aria-haspopup="true"
+          title={intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' })}
+          ariaLabel={intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' })}
+          onClick={() => onLinkRecord(authority)}
+        />
+      );
+    },
   };
 
   const visibleColumns = [

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -40,7 +40,7 @@ describe('Given BrowseView', () => {
       onNeedMoreData: expect.any(Function),
       onSubmitSearch: expect.any(Function),
       onLinkRecord: mockOnLinkRecord,
-      query: undefined,
+      query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
       searchQuery: '',
       totalRecords: NaN,
     };


### PR DESCRIPTION
## Purpose
Browse: Remove the link action on a placeholder row 

## Approach
Link button is render if `authority` has an `id` property.

## Issues
[UIPFAUTH-28](https://issues.folio.org/browse/UIPFAUTH-28)