### PR TITLE
UIPFAUTH-31: updated base column widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [UIPFAUTH-21](https://issues.folio.org/browse/UIPFAUTH-21) The error "Something went wrong" appears when search by same search option and updated query
 * [UIPFAUTH-26](https://issues.folio.org/browse/UIPFAUTH-26) The pane size of the "Search & filter" pane changes when user changes scale of the screen
 * [UIPFAUTH-28](https://issues.folio.org/browse/UIPFAUTH-28) Browse: Remove the link action on a placeholder row
+* [UIPFAUTH-31](https://issues.folio.org/browse/UIPFAUTH-31) Results List | Heading Type column is cutoff
 
 ## [0.1.0](https://github.com/folio-org/ui-plugin-find-authority/tree/v0.1.0) (2022-10-04)
 

--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -4,7 +4,7 @@ export const MAIN_PANE_HEIGHT = '609px';
 export const columnWidths = {
   [searchResultListColumns.LINK]: { min: 45, max: 45 },
   [searchResultListColumns.SELECT]: { min: 30, max: 30 },
-  [searchResultListColumns.AUTH_REF_TYPE]: { min: 155, max: 166 },
-  [searchResultListColumns.HEADING_REF]: { min: 390, max: 435 },
-  [searchResultListColumns.HEADING_TYPE]: { min: 140, max: 145 },
+  [searchResultListColumns.AUTH_REF_TYPE]: { min: 130, max: 140 },
+  [searchResultListColumns.HEADING_REF]: { min: 390, max: 410 },
+  [searchResultListColumns.HEADING_TYPE]: { min: 120, max: 130 },
 };


### PR DESCRIPTION
## Purpose
Update columns widths so that the Heading type column values are not cut off.

## Issues
[UIPFAUTH-31](https://issues.folio.org/browse/UIPFAUTH-31)