### PR TITLE
UIPFAUTH-34: The pagination buttons are missing when the user changes the scale of the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIPFAUTH-32](https://issues.folio.org/browse/UIPFAUTH-32) Added aria-label to modal
 * [UIPFAUTH-31](https://issues.folio.org/browse/UIPFAUTH-31) Results List | Heading Type column is cutoff
 * [UIPFAUTH-29](https://issues.folio.org/browse/UIPFAUTH-29) Find Authority plugin: Add a11y tests
+* [UIPFAUTH-34](https://issues.folio.org/browse/UIPFAUTH-34) The pagination buttons are missing when the user changes the scale of the screen
 
 ## [0.1.0](https://github.com/folio-org/ui-plugin-find-authority/tree/v0.1.0) (2022-10-04)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -29,7 +29,6 @@ import {
 import MarcAuthorityView from '../MarcAuthorityView';
 import {
   columnWidths,
-  MAIN_PANE_HEIGHT,
   PAGE_SIZE,
 } from '../../constants';
 import css from './AuthoritiesLookup.css';
@@ -199,7 +198,6 @@ const AuthoritiesLookup = ({
       firstMenu={renderResultsFirstMenu()}
       padContent={false}
       noOverflow
-      height={MAIN_PANE_HEIGHT}
     >
       <SearchResultsList
         authorities={authorities}
@@ -234,7 +232,6 @@ const AuthoritiesLookup = ({
         isLoading={isLoading}
         onSubmitSearch={handleSubmitSearch}
         query={query}
-        height={MAIN_PANE_HEIGHT}
         excludedSearchFilters={excludedFilters}
         excludedBrowseFilters={excludedFilters}
         onShowDetailView={setShowDetailView}

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -23,8 +23,6 @@ import {
 } from '@folio/stripes/core';
 import MarcView from '@folio/quick-marc/src/QuickMarcView/QuickMarcView';
 
-import { MAIN_PANE_HEIGHT } from '../../constants';
-
 const propTypes = {
   onCloseDetailView: PropTypes.func.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
@@ -77,7 +75,6 @@ const MarcAuthorityView = ({
     <MarcView
       isPaneset={false}
       paneWidth="fill"
-      paneHeight={MAIN_PANE_HEIGHT}
       paneTitle={authority.data.headingRef}
       paneSub={paneSub}
       marcTitle={intl.formatMessage({ id: 'stripes-authority-components.marcHeading' })}

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -45,6 +45,7 @@ const SearchModal = ({
       contentClass={css.modalContent}
     >
       <PersistedPaneset
+        static
         appId="@folio/find-authority"
         id="find-authority-paneset"
         data-testid="find-authority-paneset"

--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -1,6 +1,5 @@
 import { searchResultListColumns } from '@folio/stripes-authority-components';
 
-export const MAIN_PANE_HEIGHT = '575px';
 export const columnWidths = {
   [searchResultListColumns.LINK]: { min: 50, max: 50 },
   [searchResultListColumns.AUTH_REF_TYPE]: { min: 130, max: 140 },


### PR DESCRIPTION
## Purpose
Have access to pagination buttons after scaling.
## Issues
[UIPFAUTH-34](https://issues.folio.org/browse/UIPFAUTH-34)
## Screencast







https://user-images.githubusercontent.com/77053927/199540762-b0311f75-d4f8-4b9f-b917-00f3c3143431.mp4




