### PR TITLE
UIPFAUTH-37: Error appears when the user executes search in "MARC Authority" app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [UIPFAUTH-31](https://issues.folio.org/browse/UIPFAUTH-31) Results List | Heading Type column is cutoff
 * [UIPFAUTH-29](https://issues.folio.org/browse/UIPFAUTH-29) Find Authority plugin: Add a11y tests
 * [UIPFAUTH-34](https://issues.folio.org/browse/UIPFAUTH-34) The pagination buttons are missing when the user changes the scale of the screen
+* [UIPFAUTH-37](https://issues.folio.org/browse/UIPFAUTH-37) Error appears when the user executes search in "MARC Authority" app
 
 ## [0.1.0](https://github.com/folio-org/ui-plugin-find-authority/tree/v0.1.0) (2022-10-04)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useContext,
   useEffect,
   useState,
@@ -118,10 +119,10 @@ const AuthoritiesLookup = ({
     setShowDetailView(false);
   };
 
-  const openDetailView = authority => {
+  const openDetailView = useCallback(authority => {
     setSelectedAuthorityRecordContext(authority);
     setShowDetailView(true);
-  };
+  }, [setSelectedAuthorityRecordContext]);
 
   const handleRowFocus = ({ selector, localClientTop }) => {
     setItemToView({


### PR DESCRIPTION
## Purpose
Fix constant re-rendering after doing a search with one result.
## Issues
[UIPFAUTH-37](https://issues.folio.org/browse/UIPFAUTH-37)
## Related PRs

[UIMARCAUTH-204](https://github.com/folio-org/ui-marc-authorities/pull/217)
[UISAUTCOMP-30](https://github.com/folio-org/stripes-authority-components/pull/44)
## Screencast








https://user-images.githubusercontent.com/77053927/203528392-17239bf0-10f8-4454-840d-9edf943539d7.mp4









