### PR TITLE
UIPFAUTH-36 fix not Authorized results in search

### DIFF
--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -14,6 +14,7 @@ import {
   PAGE_SIZE,
   PRECEDING_RECORDS_COUNT,
 } from '../../constants';
+import { addDefaultFilters } from '../utils';
 
 const propTypes = {
   onLinkRecord: PropTypes.func.isRequired,
@@ -40,7 +41,7 @@ const BrowseView = ({ onLinkRecord }) => {
     query,
     totalRecords,
   } = useAuthoritiesBrowse({
-    filters,
+    filters: addDefaultFilters(searchQuery, filters),
     searchQuery,
     searchIndex,
     pageSize: PAGE_SIZE,

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -1,4 +1,7 @@
-import { useContext } from 'react';
+import {
+  useContext,
+  useMemo,
+} from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -9,6 +12,7 @@ import {
 
 import { AuthoritiesLookup } from '../../components';
 import { PAGE_SIZE } from '../../constants';
+import { addDefaultFilters } from '../utils';
 
 const propTypes = {
   onLinkRecord: PropTypes.func.isRequired,
@@ -27,6 +31,7 @@ const SearchView = ({ onLinkRecord }) => {
     setAdvancedSearchRows: setAdvancedSearch,
   } = useContext(AuthoritiesSearchContext);
   const isAdvancedSearch = searchIndex === searchableIndexesValues.ADVANCED_SEARCH;
+  const filtersWithDefault = useMemo(() => addDefaultFilters(searchQuery, filters), [searchQuery, filters]);
 
   const {
     authorities,
@@ -40,7 +45,7 @@ const SearchView = ({ onLinkRecord }) => {
     searchIndex,
     advancedSearch,
     isAdvancedSearch,
-    filters,
+    filters: filtersWithDefault,
     pageSize: PAGE_SIZE,
   });
 

--- a/src/views/SearchView/SearchView.test.js
+++ b/src/views/SearchView/SearchView.test.js
@@ -79,4 +79,40 @@ describe('Given SearchView', () => {
       expect(useAuthorities).toHaveBeenLastCalledWith(expect.objectContaining({ filters: {} }));
     });
   });
+
+  describe('when there is search query', () => {
+    it('should add the complementary filter to retrieve only Authorized records', () => {
+      const authoritiesCtxValue = {
+        searchQuery: 'foo',
+        filters: {},
+      };
+      const expectedFilters = {
+        filters: {
+          references: ['excludeSeeFrom', 'excludeSeeFromAlso'],
+        },
+      };
+
+      renderSearchView(null, authoritiesCtxValue);
+      expect(useAuthorities).toHaveBeenLastCalledWith(expect.objectContaining(expectedFilters));
+    });
+  });
+
+  describe('when there is a selected filter', () => {
+    it('should add the complementary filter to retrieve only Authorized records', () => {
+      const authoritiesCtxValue = {
+        filters: {
+          headingType: ['Topical'],
+        },
+      };
+      const expectedFilters = {
+        filters: {
+          ...authoritiesCtxValue.filters,
+          references: ['excludeSeeFrom', 'excludeSeeFromAlso'],
+        },
+      };
+
+      renderSearchView(null, authoritiesCtxValue);
+      expect(useAuthorities).toHaveBeenLastCalledWith(expect.objectContaining(expectedFilters));
+    });
+  });
 });

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -1,0 +1,21 @@
+import isEmpty from 'lodash/isEmpty';
+
+import {
+  FILTERS,
+  REFERENCES_VALUES_MAP,
+} from '@folio/stripes-authority-components';
+
+export const addDefaultFilters = (searchQuery, filters) => {
+  const shouldBeRequest = searchQuery || !isEmpty(filters);
+  const defaultFilters = {
+    [FILTERS.REFERENCES]: [
+      REFERENCES_VALUES_MAP.excludeSeeFrom,
+      REFERENCES_VALUES_MAP.excludeSeeFromAlso,
+    ],
+  };
+
+  return {
+    ...filters,
+    ...shouldBeRequest && defaultFilters,
+  };
+};


### PR DESCRIPTION
## Description
Fix not Authorized result showing after resetting filters

Need to always keep REFERENCES filter so only authorized records are searched

## Screenshots

https://user-images.githubusercontent.com/19309423/209955436-e62b2d57-a614-4b6e-bf3b-cb0f41c6f44f.mp4


## Issues
[UISAUTCOMP-34](https://issues.folio.org/browse/UISAUTCOMP-34)