### PR TITLE
UIPFAUTH-45: bump stripes to 8.0.0 for Orchid/2023-R1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIPFAUTH-34](https://issues.folio.org/browse/UIPFAUTH-34) The pagination buttons are missing when the user changes the scale of the screen
 * [UIPFAUTH-36](https://issues.folio.org/browse/UIPFAUTH-36) Default search/browse option and Authority source file selections based on MARC bib field to be linked
+* [UIPFAUTH-37](https://issues.folio.org/browse/UIPFAUTH-37) bump stripes to 8.0.0 for Orchid/2023-R1
 
 ## [1.0.1] (https://github.com/folio-org/ui-plugin-find-authority/tree/v1.0.1) (2022-11-28)
 

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-react": "^7.10.4",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-authority-components": "^1.0.0",
     "@folio/stripes-cli": "^2.6.0",
-    "@folio/stripes-core": "^8.0.0",
+    "@folio/stripes-core": "^9.0.0",
     "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^4.2.20",
     "@testing-library/jest-dom": "^5.11.1",
@@ -67,7 +67,7 @@
     "query-string": "^7.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-authority-components": "^1.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-authority",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Stripes plugin to find authorities",
   "repository": "folio-org/ui-plugin-find-authority",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-react": "^7.10.4",
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/stripes": "^8.0.0",
-    "@folio/stripes-authority-components": "^1.0.0",
+    "@folio/stripes-authority-components": "^2.0.0",
     "@folio/stripes-cli": "^2.6.0",
     "@folio/stripes-core": "^9.0.0",
     "@folio/stripes-testing": "^4.2.0",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^8.0.0",
-    "@folio/stripes-authority-components": "^1.0.0",
+    "@folio/stripes-authority-components": "^2.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",


### PR DESCRIPTION
## Purpose
Bump stripes to 8.0.0
## Issue
[UIPFAUTH-45](https://issues.folio.org/browse/UIPFAUTH-45)
## Related PR
[stripes-authority-components](https://github.com/folio-org/stripes-authority-components/pull/53)