### PR TITLE
UIPFAUTH-59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UIPFAUTH-44](https://issues.folio.org/browse/UIPFAUTH-44) Show an error message in modal after linking.
 * [UIPFAUTH-56](https://issues.folio.org/browse/UIPFAUTH-56) Avoid private paths in stripes-core imports.
 * [UIPFAUTH-57](https://issues.folio.org/browse/UIPFAUTH-57) Added stripes-authority-components to stripesDeps.
+* [UIPFAUTH-59](https://issues.folio.org/browse/UIPFAUTH-59) Browse: Fix Space at the begining and end of query string.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -52,7 +52,7 @@ const BrowseView = ({
   });
 
   const onSubmitSearch = () => {
-    setSearchQuery(searchInputValue);
+    setSearchQuery(searchInputValue.trim());
     setSearchIndex(searchDropdownValue);
   };
 


### PR DESCRIPTION
## Description
Browse: Fix Space at the begining and end of query string. The same fix as in UIMARCAUTH-251
## Issues
[UIPFAUTH-59](https://issues.folio.org/browse/UIPFAUTH-59)