### PR TITLE
UIPFAUTH-51: Fix the focus of the first result for the Browse search

### DIFF
--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -48,6 +48,7 @@ const propTypes = {
   onNeedMoreData: PropTypes.func.isRequired,
   onSubmitSearch: PropTypes.func.isRequired,
   query: PropTypes.string,
+  resultsContainerRef: PropTypes.node,
   searchQuery: PropTypes.string.isRequired,
   totalRecords: PropTypes.number.isRequired,
 };
@@ -66,6 +67,7 @@ const AuthoritiesLookup = ({
   hasNextPage,
   hasPrevPage,
   hidePageIndices,
+  resultsContainerRef,
   onNeedMoreData,
   onSubmitSearch,
   onLinkRecord,
@@ -238,6 +240,7 @@ const AuthoritiesLookup = ({
         hasPrevPage={hasPrevPage}
         hidePageIndices={hidePageIndices}
         renderHeadingRef={renderHeadingRef}
+        resultsContainerRef={resultsContainerRef}
         itemToView={itemToView}
         onRowFocus={handleRowFocus}
       />
@@ -277,6 +280,7 @@ AuthoritiesLookup.defaultProps = {
   hasNextPage: null,
   hasPrevPage: null,
   hidePageIndices: false,
+  resultsContainerRef: null,
 };
 
 export default AuthoritiesLookup;

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import {
   AuthoritiesSearchContext,
   useAuthoritiesBrowse,
+  useBrowseResultFocus,
 } from '@folio/stripes-authority-components';
 
 import { AuthoritiesLookup } from '../../components';
@@ -51,6 +52,13 @@ const BrowseView = ({
     precedingRecordsCount: PRECEDING_RECORDS_COUNT,
   });
 
+  const { resultsContainerRef, isPaginationClicked } = useBrowseResultFocus(isLoading);
+
+  const handleNeedMoreData = (...params) => {
+    isPaginationClicked.current = true;
+    handleLoadMore(...params);
+  };
+
   const onSubmitSearch = () => {
     setSearchQuery(searchInputValue.trim());
     setSearchIndex(searchDropdownValue);
@@ -83,7 +91,8 @@ const BrowseView = ({
       hasNextPage={hasNextPage}
       hasPrevPage={hasPrevPage}
       hidePageIndices
-      onNeedMoreData={handleLoadMore}
+      resultsContainerRef={resultsContainerRef}
+      onNeedMoreData={handleNeedMoreData}
       onSubmitSearch={onSubmitSearch}
       onLinkRecord={onLinkRecord}
     />

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -1,17 +1,23 @@
 import { render } from '@testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
+import {
+  useAuthoritiesBrowse,
+  useBrowseResultFocus,
+} from '@folio/stripes-authority-components';
 
 import BrowseView from './BrowseView';
 
 import Harness from '../../../test/jest/helpers/harness';
 import AuthoritiesLookup from '../../components/AuthoritiesLookup';
 
+const mockIsPaginationClicked = { current: false };
+const mockHandleLoadMore = jest.fn();
+
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
-  useBrowseResultFocus: jest.fn().mockReturnValue({
-    resultsContainerRef: { current: null },
-  }),
+  useAuthoritiesBrowse: jest.fn(),
+  useBrowseResultFocus: jest.fn(),
 }));
 
 jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
@@ -29,6 +35,25 @@ const renderBrowseView = (props = {}) => render(
 );
 
 describe('Given BrowseView', () => {
+  beforeEach(() => {
+    mockIsPaginationClicked.current = false;
+
+    useAuthoritiesBrowse.mockReturnValue({
+      authorities: [],
+      hasNextPage: false,
+      hasPrevPage: false,
+      isLoading: false,
+      isLoaded: false,
+      handleLoadMore: mockHandleLoadMore,
+      query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
+      totalRecords: 0,
+    });
+    useBrowseResultFocus.mockReturnValue({
+      resultsContainerRef: { current: null },
+      isPaginationClicked: mockIsPaginationClicked,
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -57,10 +82,22 @@ describe('Given BrowseView', () => {
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
       resultsContainerRef: { current: null },
       searchQuery: '',
-      totalRecords: NaN,
+      totalRecords: 0,
     };
 
     renderBrowseView();
-    expect(AuthoritiesLookup).toHaveBeenNthCalledWith(2, expectedProps, {});
+    expect(AuthoritiesLookup).toHaveBeenNthCalledWith(1, expectedProps, {});
+  });
+
+  describe('when a user clicks on the pagination button', () => {
+    it('should invoke handleLoadMore and assign isPaginationClicked to true', () => {
+      const args = [100, 95, 0, 'next'];
+
+      renderBrowseView();
+      AuthoritiesLookup.mock.calls[0][0].onNeedMoreData(...args);
+
+      expect(mockHandleLoadMore).toHaveBeenCalledWith(...args);
+      expect(mockIsPaginationClicked.current).toBeTruthy();
+    });
   });
 });

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -7,6 +7,13 @@ import BrowseView from './BrowseView';
 import Harness from '../../../test/jest/helpers/harness';
 import AuthoritiesLookup from '../../components/AuthoritiesLookup';
 
+jest.mock('@folio/stripes-authority-components', () => ({
+  ...jest.requireActual('@folio/stripes-authority-components'),
+  useBrowseResultFocus: jest.fn().mockReturnValue({
+    resultsContainerRef: { current: null },
+  }),
+}));
+
 jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
 
 const mockOnLinkRecord = jest.fn();
@@ -42,17 +49,18 @@ describe('Given BrowseView', () => {
       hasPrevPage: false,
       hidePageIndices: true,
       isLinkingLoading: false,
-      isLoaded: true,
+      isLoaded: false,
       isLoading: false,
       onNeedMoreData: expect.any(Function),
       onSubmitSearch: expect.any(Function),
       onLinkRecord: mockOnLinkRecord,
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
+      resultsContainerRef: { current: null },
       searchQuery: '',
-      totalRecords: 0,
+      totalRecords: NaN,
     };
 
     renderBrowseView();
-    expect(AuthoritiesLookup).toHaveBeenNthCalledWith(1, expectedProps, {});
+    expect(AuthoritiesLookup).toHaveBeenNthCalledWith(2, expectedProps, {});
   });
 });


### PR DESCRIPTION
## Purpose
The focus should always be on the first result after clicking the previous/next button.

## Issues
[UIPFAUTH-51](https://issues.folio.org/browse/UIPFAUTH-51)

## Related PRs
[stripes-authority-components/pull/79](https://github.com/folio-org/stripes-authority-components/pull/79)
[ui-marc-authorities/pull/282](https://github.com/folio-org/ui-marc-authorities/pull/282)

## Screencast



https://user-images.githubusercontent.com/77053927/236485183-43286442-a9db-482a-8a8b-cbdea12002c1.mp4





