### PR TITLE
UIPFAUTH-61: Retain Search and Browse search terms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UIPFAUTH-59](https://issues.folio.org/browse/UIPFAUTH-59) Browse: Fix Space at the begining and end of query string.
 * [UIPFAUTH-60](https://issues.folio.org/browse/UIPFAUTH-60) Display link button when open Authorized or Reference.
 * [UIPFAUTH-62](https://issues.folio.org/browse/UIPFAUTH-62) "Month" dropdown is Not displayed in date picker element opened in modal window
+* [UIPFAUTH-61](https://issues.folio.org/browse/UIPFAUTH-61) Retain `Search` and `Browse` search terms.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -33,6 +33,9 @@ const BrowseView = ({
     setSearchIndex,
     searchInputValue,
     searchDropdownValue,
+    setBrowsePageQuery,
+    browsePageQuery,
+    navigationSegmentValue,
   } = useContext(AuthoritiesSearchContext);
 
   const {
@@ -50,6 +53,9 @@ const BrowseView = ({
     searchIndex,
     pageSize: PAGE_SIZE,
     precedingRecordsCount: PRECEDING_RECORDS_COUNT,
+    setBrowsePageQuery,
+    browsePageQuery,
+    navigationSegmentValue,
   });
 
   const { resultsContainerRef, isPaginationClicked } = useBrowseResultFocus(isLoading);

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -29,6 +29,9 @@ const SearchView = ({
     searchInputValue,
     searchDropdownValue,
     setAdvancedSearchRows: setAdvancedSearch,
+    navigationSegmentValue,
+    offset,
+    setOffset,
   } = useContext(AuthoritiesSearchContext);
   const isAdvancedSearch = searchIndex === searchableIndexesValues.ADVANCED_SEARCH;
 
@@ -37,7 +40,6 @@ const SearchView = ({
     isLoading,
     isLoaded,
     totalRecords,
-    setOffset,
     query,
   } = useAuthorities({
     searchQuery,
@@ -46,6 +48,9 @@ const SearchView = ({
     isAdvancedSearch,
     filters,
     pageSize: PAGE_SIZE,
+    offset,
+    setOffset,
+    navigationSegmentValue,
   });
 
   const onSubmitSearch = (e, advancedSearchState) => {


### PR DESCRIPTION
## Purpose
Retain Search and Browse search terms.

## Issue

## Related PRs

## Screencast


https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/53ee712c-c38a-4f19-99d9-46ad6ccabeeb


