### PR TITLE
UIPFAUTH-70 Update Node.js to v18 in GitHub Actions

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -28,7 +28,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -24,7 +24,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       SQ_LCOV_REPORT: 'artifacts/coverage-jest/lcov.info'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [UIPFAUTH-61](https://issues.folio.org/browse/UIPFAUTH-61) Retain `Search` and `Browse` search terms.
 * [UIPFAUTH-67](https://issues.folio.org/browse/UIPFAUTH-67) Update markHighlightedFields function with authority Mapping Rules
 * [UIPFAUTH-121](https://issues.folio.org/browse/UIPFAUTH-121) *BREAKING* Bump `react` to `v18`.
+* [UIPFAUTH-70](https://issues.folio.org/browse/UIPFAUTH-70) Update Node.js to v18 in GitHub Actions.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=14.0.0"
-  },
   "stripes": {
     "actsAs": [
       "plugin"


### PR DESCRIPTION
## Description
Update Node.js to v18 in GitHub Actions

## Issues
[UIPFAUTH-70](https://issues.folio.org/browse/UIPFAUTH-70)