### PR TITLE
UIPFAUTH-73: Add 'Local' or 'Shared' to flag MARC authorities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [UIPFAUTH-67](https://issues.folio.org/browse/UIPFAUTH-67) Update markHighlightedFields function with authority Mapping Rules
 * [UIPFAUTH-121](https://issues.folio.org/browse/UIPFAUTH-121) *BREAKING* Bump `react` to `v18`.
 * [UIPFAUTH-70](https://issues.folio.org/browse/UIPFAUTH-70) Update Node.js to v18 in GitHub Actions.
+* [UIPFAUTH-73](https://issues.folio.org/browse/UIPFAUTH-73) Add "Local" or "Shared" to flag MARC authorities.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -24,9 +24,14 @@ import {
 import {
   useCallout,
   useNamespace,
+  useStripes,
 } from '@folio/stripes/core';
 import MarcView from '@folio/quick-marc/src/QuickMarcView/QuickMarcView';
-import { headFieldValue } from '../utils';
+
+import {
+  headFieldValue,
+  isConsortiaEnv,
+} from '../utils';
 
 import css from './MarcAuthorityView.css';
 
@@ -41,6 +46,7 @@ const MarcAuthorityView = ({
   onCloseDetailView,
   onLinkRecord,
 }) => {
+  const stripes = useStripes();
   const queryClient = useQueryClient();
   const authoritySourceNamespace = useNamespace({ key: QUERY_KEY_AUTHORITY_SOURCE });
   const callout = useCallout();
@@ -116,6 +122,15 @@ const MarcAuthorityView = ({
     );
   };
 
+  const paneTitle = intl.formatMessage({ id: 'stripes-authority-components.authorityRecordTitle' }, {
+    shared: isConsortiaEnv(stripes) ? authority.data.shared : null,
+    title: authority.data.headingRef,
+  });
+
+  const marcTitle = intl.formatMessage({ id: 'stripes-authority-components.marcHeading' }, {
+    shared: isConsortiaEnv(stripes) ? authority.data.shared : null,
+  });
+
   const paneSub = intl.formatMessage({ id: 'stripes-authority-components.authorityRecordSubtitle' }, {
     heading: authority.data.headingType,
     lastUpdatedDate: intl.formatDate(marcSource.data.metadata.updatedDate),
@@ -125,9 +140,9 @@ const MarcAuthorityView = ({
     <MarcView
       isPaneset={false}
       paneWidth="fill"
-      paneTitle={authority.data.headingRef}
+      paneTitle={paneTitle}
       paneSub={paneSub}
-      marcTitle={intl.formatMessage({ id: 'stripes-authority-components.marcHeading' })}
+      marcTitle={marcTitle}
       marc={markHighlightedFields(marcSource, authority, authorityMappingRules).data}
       onClose={onCloseDetailView}
       lastMenu={renderLastMenu()}

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -14,3 +14,5 @@ export const headFieldValue = (authority, marcSource) => {
 
   return marcHeadFieldValue;
 };
+
+export const isConsortiaEnv = stripes => stripes.hasInterface('consortia');


### PR DESCRIPTION
## Purpose
Add `Local` or `Shared` to flag MARC authorities.
## Related PRs:
https://github.com/folio-org/ui-quick-marc/pull/578
https://github.com/folio-org/ui-marc-authorities/pull/304
https://github.com/folio-org/stripes-authority-components/pull/94

## Issue
[UIPFAUTH-73](https://issues.folio.org/browse/UIPFAUTH-73)
