### PR TITLE
UIPFAUTH-74 Add Shared icon to Find authority plugin search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [UIPFAUTH-121](https://issues.folio.org/browse/UIPFAUTH-121) *BREAKING* Bump `react` to `v18`.
 * [UIPFAUTH-70](https://issues.folio.org/browse/UIPFAUTH-70) Update Node.js to v18 in GitHub Actions.
 * [UIPFAUTH-73](https://issues.folio.org/browse/UIPFAUTH-73) Add "Local" or "Shared" to flag MARC authorities.
+* [UIPFAUTH-74](https://issues.folio.org/browse/UIPFAUTH-74) Add Shared icon to MARC authority search results.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -26,6 +26,7 @@ import {
   navigationSegments,
   useAutoOpenDetailView,
   AUTH_REF_TYPES,
+  SharedIcon,
 } from '@folio/stripes-authority-components';
 
 import MarcAuthorityView from '../MarcAuthorityView';
@@ -205,6 +206,7 @@ const AuthoritiesLookup = ({
       data-testid="heading-ref-btn"
       onClick={() => setShowDetailView(true)}
     >
+      {authority.shared && <SharedIcon authority={authority} />}
       {authority.headingRef}
     </button>
   );

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -155,4 +155,12 @@ describe('Given AuthoritiesLookup', () => {
       expect(mockSetSelectedAuthorityRecord).toHaveBeenLastCalledWith(null);
     });
   });
+
+  describe('when Authority record is shared', () => {
+    it('should render shared icon', () => {
+      const { getByText } = renderAuthoritiesSearchPane();
+
+      expect(getByText('stripes-authority-components.search.shared')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Description
Add Shared icon to Find authority plugin search results

## Screenshots
![image](https://github.com/folio-org/ui-plugin-find-authority/assets/19309423/6d7aa768-c491-4d20-8ccf-1ebf9e62ea06)

## Issues
[UIPFAUTH-74](https://issues.folio.org/browse/UIPFAUTH-74)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/97
https://github.com/folio-org/ui-marc-authorities/pull/305