### PR TITLE
UIPFAUTH-75  Change tenant id to central when opening details of Shared Authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [UIPFAUTH-70](https://issues.folio.org/browse/UIPFAUTH-70) Update Node.js to v18 in GitHub Actions.
 * [UIPFAUTH-73](https://issues.folio.org/browse/UIPFAUTH-73) Add "Local" or "Shared" to flag MARC authorities.
 * [UIPFAUTH-74](https://issues.folio.org/browse/UIPFAUTH-74) Add Shared icon to MARC authority search results.
+* [UIPFAUTH-75](https://issues.folio.org/browse/UIPFAUTH-75) Change tenant id to central when opening details of Shared Authority.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -52,9 +52,10 @@ const MarcAuthorityView = ({
   const callout = useCallout();
   const intl = useIntl();
   const [selectedAuthorityRecord] = useContext(SelectedAuthorityRecordContext);
-  const { id, authRefType, headingRef } = selectedAuthorityRecord;
+  const { id, authRefType, headingRef, shared } = selectedAuthorityRecord;
+  const tenantId = shared ? stripes.user.user.consortium?.centralTenantId : selectedAuthorityRecord.tenantId;
 
-  const { authorityMappingRules } = useAuthorityMappingRules();
+  const { authorityMappingRules } = useAuthorityMappingRules({ tenantId, enabled: Boolean(selectedAuthorityRecord) });
 
   const handleAuthorityLoadError = async err => {
     const errorResponse = await err.response;
@@ -67,11 +68,11 @@ const MarcAuthorityView = ({
     queryClient.invalidateQueries(authoritySourceNamespace);
   };
 
-  const marcSource = useMarcSource(id, {
+  const marcSource = useMarcSource({ recordId: id, tenantId }, {
     onError: handleAuthorityLoadError,
   });
 
-  const authority = useAuthority(id, authRefType, headingRef, {
+  const authority = useAuthority({ recordId: id, authRefType, headingRef, tenantId }, {
     onError: handleAuthorityLoadError,
   });
 
@@ -146,6 +147,7 @@ const MarcAuthorityView = ({
       marc={markHighlightedFields(marcSource, authority, authorityMappingRules).data}
       onClose={onCloseDetailView}
       lastMenu={renderLastMenu()}
+      tenantId={tenantId}
     />
   );
 };

--- a/src/components/MarcAuthorityView/MarcAuthorityView.test.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.test.js
@@ -261,4 +261,39 @@ describe('Given MarcAuthorityView', () => {
       });
     });
   });
+
+  describe('when authority is shared', () => {
+    it('should fetch data from central tenant', () => {
+      const selectedAuthority = {
+        shared: true,
+      };
+
+      renderMarcAuthorityView(null, selectedAuthority);
+
+      expect(useMarcSource.mock.calls[0][0]).toEqual({
+        tenantId: 'consortia',
+      });
+      expect(useAuthority.mock.calls[0][0]).toEqual({
+        tenantId: 'consortia',
+      });
+    });
+  });
+
+  describe('when authority is local', () => {
+    it('should fetch data with authority.tenantId', () => {
+      const selectedAuthority = {
+        shared: false,
+        tenantId: 'university',
+      };
+
+      renderMarcAuthorityView(null, selectedAuthority);
+
+      expect(useMarcSource.mock.calls[0][0]).toEqual({
+        tenantId: selectedAuthority.tenantId,
+      });
+      expect(useAuthority.mock.calls[0][0]).toEqual({
+        tenantId: selectedAuthority.tenantId,
+      });
+    });
+  });
 });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -33,6 +33,9 @@ const buildStripes = (otherProperties = {}) => ({
     user: {
       id: 'b1add99d-530b-5912-94f3-4091b4d87e2c',
       username: 'diku_admin',
+      consortium: {
+        centralTenantId: 'consortia',
+      },
     },
   },
   withOkapi: true,


### PR DESCRIPTION
## Description
Change tenant id to central when opening details of Shared Authority

## Issues
[UIPFAUTH-75](https://issues.folio.org/browse/UIPFAUTH-75)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/306
https://github.com/folio-org/stripes-authority-components/pull/99
https://github.com/folio-org/ui-quick-marc/pull/580