### PR TITLE
UIPFAUTH-76: Link Shared/Local MARC bib record to Shared/Local Authority record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [UIPFAUTH-73](https://issues.folio.org/browse/UIPFAUTH-73) Add "Local" or "Shared" to flag MARC authorities.
 * [UIPFAUTH-74](https://issues.folio.org/browse/UIPFAUTH-74) Add Shared icon to MARC authority search results.
 * [UIPFAUTH-75](https://issues.folio.org/browse/UIPFAUTH-75) Change tenant id to central when opening details of Shared Authority.
+* [UIPFAUTH-76](https://issues.folio.org/browse/UIPFAUTH-76) Link Shared/Local MARC bib record to Shared/Local Authority record.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/FindAuthority.js
+++ b/src/FindAuthority.js
@@ -22,17 +22,20 @@ const propTypes = {
   isLinkingLoading: PropTypes.bool.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
   renderCustomTrigger: PropTypes.func,
+  tenantId: PropTypes.string,
 };
 
 const defaultProps = {
   calloutRef: null,
   initialValues: {},
   renderCustomTrigger: null,
+  tenantId: '',
 };
 
 const FindAuthority = ({
   calloutRef,
   isLinkingLoading,
+  tenantId,
   initialValues,
   renderCustomTrigger,
   onLinkRecord,
@@ -81,6 +84,7 @@ const FindAuthority = ({
           <SelectedAuthorityRecordContextProvider>
             <SearchModal
               isLinkingLoading={isLinkingLoading}
+              tenantId={tenantId}
               open={isOpen}
               onClose={closeModal}
               onLinkRecord={handleLinkAuthority}

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -51,6 +51,7 @@ const propTypes = {
   query: PropTypes.string,
   resultsContainerRef: PropTypes.node,
   searchQuery: PropTypes.string.isRequired,
+  tenantId: PropTypes.string,
   totalRecords: PropTypes.number.isRequired,
 };
 
@@ -69,6 +70,7 @@ const AuthoritiesLookup = ({
   hasPrevPage,
   hidePageIndices,
   resultsContainerRef,
+  tenantId,
   onNeedMoreData,
   onSubmitSearch,
   onLinkRecord,
@@ -259,6 +261,7 @@ const AuthoritiesLookup = ({
         query={query}
         excludedSearchFilters={excludedFilters}
         excludedBrowseFilters={excludedFilters}
+        tenantId={tenantId}
         onShowDetailView={setShowDetailView}
       />
       {showDetailView
@@ -283,6 +286,7 @@ AuthoritiesLookup.defaultProps = {
   hasPrevPage: null,
   hidePageIndices: false,
   resultsContainerRef: null,
+  tenantId: '',
 };
 
 export default AuthoritiesLookup;

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -21,10 +21,16 @@ const propTypes = {
   onClose: PropTypes.func.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
+  tenantId: PropTypes.string,
+};
+
+const defaultProps = {
+  tenantId: '',
 };
 
 const SearchModal = ({
   isLinkingLoading,
+  tenantId,
   open,
   onClose,
   onLinkRecord,
@@ -58,12 +64,14 @@ const SearchModal = ({
             ? (
               <SearchView
                 isLinkingLoading={isLinkingLoading}
+                tenantId={tenantId}
                 onLinkRecord={onLinkRecord}
               />
             )
             : (
               <BrowseView
                 isLinkingLoading={isLinkingLoading}
+                tenantId={tenantId}
                 onLinkRecord={onLinkRecord}
               />
             )
@@ -74,5 +82,6 @@ const SearchModal = ({
 };
 
 SearchModal.propTypes = propTypes;
+SearchModal.defaultProps = defaultProps;
 
 export default SearchModal;

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -19,10 +19,16 @@ import {
 const propTypes = {
   isLinkingLoading: PropTypes.bool.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
+  tenantId: PropTypes.string,
+};
+
+const defaultProps = {
+  tenantId: '',
 };
 
 const BrowseView = ({
   isLinkingLoading,
+  tenantId,
   onLinkRecord,
 }) => {
   const {
@@ -60,6 +66,7 @@ const BrowseView = ({
     browsePage,
     setBrowsePage,
     navigationSegmentValue,
+    tenantId,
   });
 
   const { resultsContainerRef, isPaginationClicked } = useBrowseResultFocus(isLoading);
@@ -102,6 +109,7 @@ const BrowseView = ({
       hasPrevPage={hasPrevPage}
       hidePageIndices
       resultsContainerRef={resultsContainerRef}
+      tenantId={tenantId}
       onNeedMoreData={handleNeedMoreData}
       onSubmitSearch={onSubmitSearch}
       onLinkRecord={onLinkRecord}
@@ -110,5 +118,6 @@ const BrowseView = ({
 };
 
 BrowseView.propTypes = propTypes;
+BrowseView.defaultProps = defaultProps;
 
 export default BrowseView;

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -85,6 +85,7 @@ describe('Given BrowseView', () => {
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
       resultsContainerRef: { current: null },
       searchQuery: '',
+      tenantId: '',
       totalRecords: 0,
     };
 

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -13,10 +13,16 @@ import { PAGE_SIZE } from '../../constants';
 const propTypes = {
   isLinkingLoading: PropTypes.bool.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
+  tenantId: PropTypes.string,
+};
+
+const defaultProps = {
+  tenantId: '',
 };
 
 const SearchView = ({
   isLinkingLoading,
+  tenantId,
   onLinkRecord,
 }) => {
   const {
@@ -51,6 +57,7 @@ const SearchView = ({
     offset,
     setOffset,
     navigationSegmentValue,
+    tenantId,
   });
 
   const onSubmitSearch = (e, advancedSearchState) => {
@@ -73,6 +80,7 @@ const SearchView = ({
       isLoaded={isLoaded}
       isLoading={isLoading}
       hasFilters={!!filters.length}
+      tenantId={tenantId}
       onNeedMoreData={handleLoadMore}
       onSubmitSearch={onSubmitSearch}
       onLinkRecord={onLinkRecord}
@@ -81,5 +89,6 @@ const SearchView = ({
 };
 
 SearchView.propTypes = propTypes;
+SearchView.defaultProps = defaultProps;
 
 export default SearchView;

--- a/src/views/SearchView/SearchView.test.js
+++ b/src/views/SearchView/SearchView.test.js
@@ -63,6 +63,7 @@ describe('Given SearchView', () => {
       onLinkRecord: mockOnLinkRecord,
       query: '',
       searchQuery: '',
+      tenantId: '',
       totalRecords: 0,
     };
 


### PR DESCRIPTION
## Purpose
Link Shared/Local MARC bib record to Shared/Local Authority record.

## Issue
[UIPFAUTH-76](https://issues.folio.org/browse/UIPFAUTH-76)

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/581
https://github.com/folio-org/stripes-authority-components/pull/100
https://github.com/folio-org/ui-inventory/pull/2242

## Screencast

https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/dbda37b0-a265-4475-b4cc-b984c65988cc


