### PR TITLE
UIPFAUTH-77: Hide the Shared facet in the plugin for the shared bib record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [UIPFAUTH-74](https://issues.folio.org/browse/UIPFAUTH-74) Add Shared icon to MARC authority search results.
 * [UIPFAUTH-75](https://issues.folio.org/browse/UIPFAUTH-75) Change tenant id to central when opening details of Shared Authority.
 * [UIPFAUTH-76](https://issues.folio.org/browse/UIPFAUTH-76) Link Shared/Local MARC bib record to Shared/Local Authority record.
+* [UIPFAUTH-77](https://issues.folio.org/browse/UIPFAUTH-77) Hide the Shared facet in the plugin for the shared bib record.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/FindAuthority.js
+++ b/src/FindAuthority.js
@@ -18,6 +18,7 @@ const propTypes = {
     PropTypes.func,
     PropTypes.object,
   ]),
+  excludedFilters: PropTypes.object,
   initialValues: PropTypes.object,
   isLinkingLoading: PropTypes.bool.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
@@ -27,6 +28,7 @@ const propTypes = {
 
 const defaultProps = {
   calloutRef: null,
+  excludedFilters: {},
   initialValues: {},
   renderCustomTrigger: null,
   tenantId: '',
@@ -34,6 +36,7 @@ const defaultProps = {
 
 const FindAuthority = ({
   calloutRef,
+  excludedFilters,
   isLinkingLoading,
   tenantId,
   initialValues,
@@ -83,6 +86,7 @@ const FindAuthority = ({
         >
           <SelectedAuthorityRecordContextProvider>
             <SearchModal
+              excludedFilters={excludedFilters}
               isLinkingLoading={isLinkingLoading}
               tenantId={tenantId}
               open={isOpen}

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -38,6 +38,7 @@ import css from './AuthoritiesLookup.css';
 
 const propTypes = {
   authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
+  excludedFilters: PropTypes.object,
   hasFilters: PropTypes.bool.isRequired,
   hasNextPage: PropTypes.bool,
   hasPrevPage: PropTypes.bool,
@@ -55,10 +56,9 @@ const propTypes = {
   totalRecords: PropTypes.number.isRequired,
 };
 
-const excludedFilters = new Set([]);
-
 const AuthoritiesLookup = ({
   authorities,
+  excludedFilters,
   totalRecords,
   searchQuery,
   query,
@@ -254,13 +254,12 @@ const AuthoritiesLookup = ({
   return (
     <>
       <AuthoritiesSearchPane
+        excludedFilters={excludedFilters}
         isFilterPaneVisible={isFilterPaneVisible}
         toggleFilterPane={toggleFilterPane}
         isLoading={isLoading}
         onSubmitSearch={handleSubmitSearch}
         query={query}
-        excludedSearchFilters={excludedFilters}
-        excludedBrowseFilters={excludedFilters}
         tenantId={tenantId}
         onShowDetailView={setShowDetailView}
       />
@@ -281,6 +280,7 @@ const AuthoritiesLookup = ({
 AuthoritiesLookup.propTypes = propTypes;
 
 AuthoritiesLookup.defaultProps = {
+  excludedFilters: {},
   query: '',
   hasNextPage: null,
   hasPrevPage: null,

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -17,6 +17,7 @@ import {
 import css from './SearchModal.css';
 
 const propTypes = {
+  excludedFilters: PropTypes.object,
   isLinkingLoading: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
@@ -25,10 +26,12 @@ const propTypes = {
 };
 
 const defaultProps = {
+  excludedFilters: {},
   tenantId: '',
 };
 
 const SearchModal = ({
+  excludedFilters,
   isLinkingLoading,
   tenantId,
   open,
@@ -63,6 +66,7 @@ const SearchModal = ({
           navigationSegmentValue === navigationSegments.search
             ? (
               <SearchView
+                excludedFilters={excludedFilters}
                 isLinkingLoading={isLinkingLoading}
                 tenantId={tenantId}
                 onLinkRecord={onLinkRecord}
@@ -70,6 +74,7 @@ const SearchModal = ({
             )
             : (
               <BrowseView
+                excludedFilters={excludedFilters}
                 isLinkingLoading={isLinkingLoading}
                 tenantId={tenantId}
                 onLinkRecord={onLinkRecord}

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -17,16 +17,19 @@ import {
 } from '../../constants';
 
 const propTypes = {
+  excludedFilters: PropTypes.object,
   isLinkingLoading: PropTypes.bool.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
   tenantId: PropTypes.string,
 };
 
 const defaultProps = {
+  excludedFilters: {},
   tenantId: '',
 };
 
 const BrowseView = ({
+  excludedFilters,
   isLinkingLoading,
   tenantId,
   onLinkRecord,
@@ -98,6 +101,7 @@ const BrowseView = ({
   return (
     <AuthoritiesLookup
       authorities={formattedAuthoritiesForView}
+      excludedFilters={excludedFilters}
       totalRecords={totalRecords}
       searchQuery={searchQuery}
       query={query}

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -72,6 +72,7 @@ describe('Given BrowseView', () => {
   it('should have correct props for AuthoritiesLookup', () => {
     const expectedProps = {
       authorities: [],
+      excludedFilters: {},
       hasFilters: false,
       hasNextPage: false,
       hasPrevPage: false,

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -11,16 +11,19 @@ import { AuthoritiesLookup } from '../../components';
 import { PAGE_SIZE } from '../../constants';
 
 const propTypes = {
+  excludedFilters: PropTypes.object,
   isLinkingLoading: PropTypes.bool.isRequired,
   onLinkRecord: PropTypes.func.isRequired,
   tenantId: PropTypes.string,
 };
 
 const defaultProps = {
+  excludedFilters: {},
   tenantId: '',
 };
 
 const SearchView = ({
+  excludedFilters,
   isLinkingLoading,
   tenantId,
   onLinkRecord,
@@ -73,6 +76,7 @@ const SearchView = ({
   return (
     <AuthoritiesLookup
       authorities={authorities}
+      excludedFilters={excludedFilters}
       totalRecords={totalRecords}
       searchQuery={searchQuery}
       query={query}

--- a/src/views/SearchView/SearchView.test.js
+++ b/src/views/SearchView/SearchView.test.js
@@ -54,6 +54,7 @@ describe('Given SearchView', () => {
   it('should have correct props for AuthoritiesLookup', () => {
     const expectedProps = {
       authorities: [],
+      excludedFilters: {},
       hasFilters: false,
       isLinkingLoading: false,
       isLoaded: true,


### PR DESCRIPTION
## Purpose
Hide the Shared facet in the plugin for the shared bib record.

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/585
https://github.com/folio-org/stripes-authority-components/pull/103

## Issue
[UISAUTCOMP-72](https://issues.folio.org/browse/UISAUTCOMP-72)
## Screencast

https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/7f01da8e-e521-4414-b3d9-d9a0a23c2b4f


