### PR TITLE
UIPFAUTH-80: Don't clear previous Search/Browse results to highlight the edited record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [UIPFAUTH-75](https://issues.folio.org/browse/UIPFAUTH-75) Change tenant id to central when opening details of Shared Authority.
 * [UIPFAUTH-76](https://issues.folio.org/browse/UIPFAUTH-76) Link Shared/Local MARC bib record to Shared/Local Authority record.
 * [UIPFAUTH-77](https://issues.folio.org/browse/UIPFAUTH-77) Hide the Shared facet in the plugin for the shared bib record.
+* [UIPFAUTH-80](https://issues.folio.org/browse/UIPFAUTH-80) Don't clear previous Search/Browse results to highlight the edited record.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -49,8 +49,8 @@ const propTypes = {
   onLinkRecord: PropTypes.func.isRequired,
   onNeedMoreData: PropTypes.func.isRequired,
   onSubmitSearch: PropTypes.func.isRequired,
+  pagingOffset: PropTypes.number,
   query: PropTypes.string,
-  resultsContainerRef: PropTypes.node,
   searchQuery: PropTypes.string.isRequired,
   tenantId: PropTypes.string,
   totalRecords: PropTypes.number.isRequired,
@@ -69,8 +69,8 @@ const AuthoritiesLookup = ({
   hasNextPage,
   hasPrevPage,
   hidePageIndices,
-  resultsContainerRef,
   tenantId,
+  pagingOffset,
   onNeedMoreData,
   onSubmitSearch,
   onLinkRecord,
@@ -232,6 +232,7 @@ const AuthoritiesLookup = ({
         formatter={formatter}
         totalResults={totalRecords}
         pageSize={PAGE_SIZE}
+        pagingOffset={pagingOffset}
         onNeedMoreData={onNeedMoreData}
         loading={isLoading}
         loaded={isLoaded}
@@ -244,7 +245,6 @@ const AuthoritiesLookup = ({
         hasPrevPage={hasPrevPage}
         hidePageIndices={hidePageIndices}
         renderHeadingRef={renderHeadingRef}
-        resultsContainerRef={resultsContainerRef}
         itemToView={itemToView}
         onRowFocus={handleRowFocus}
       />
@@ -285,7 +285,7 @@ AuthoritiesLookup.defaultProps = {
   hasNextPage: null,
   hasPrevPage: null,
   hidePageIndices: false,
-  resultsContainerRef: null,
+  pagingOffset: null,
   tenantId: '',
 };
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -285,7 +285,7 @@ AuthoritiesLookup.defaultProps = {
   hasNextPage: null,
   hasPrevPage: null,
   hidePageIndices: false,
-  pagingOffset: null,
+  pagingOffset: undefined, // undefined is required
   tenantId: '',
 };
 

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import {
   AuthoritiesSearchContext,
   useAuthoritiesBrowse,
-  useBrowseResultFocus,
 } from '@folio/stripes-authority-components';
 
 import { AuthoritiesLookup } from '../../components';
@@ -72,13 +71,6 @@ const BrowseView = ({
     tenantId,
   });
 
-  const { resultsContainerRef, isPaginationClicked } = useBrowseResultFocus(isLoading);
-
-  const handleNeedMoreData = (...params) => {
-    isPaginationClicked.current = true;
-    handleLoadMore(...params);
-  };
-
   const onSubmitSearch = () => {
     setSearchQuery(searchInputValue.trim());
     setSearchIndex(searchDropdownValue);
@@ -112,9 +104,9 @@ const BrowseView = ({
       hasNextPage={hasNextPage}
       hasPrevPage={hasPrevPage}
       hidePageIndices
-      resultsContainerRef={resultsContainerRef}
+      pagingOffset={0} // any number allows us to always focus on the first row after the pagination change.
       tenantId={tenantId}
-      onNeedMoreData={handleNeedMoreData}
+      onNeedMoreData={handleLoadMore}
       onSubmitSearch={onSubmitSearch}
       onLinkRecord={onLinkRecord}
     />

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -4,23 +4,18 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
-import {
-  useAuthoritiesBrowse,
-  useBrowseResultFocus,
-} from '@folio/stripes-authority-components';
+import { useAuthoritiesBrowse } from '@folio/stripes-authority-components';
 
 import BrowseView from './BrowseView';
 
 import Harness from '../../../test/jest/helpers/harness';
 import AuthoritiesLookup from '../../components/AuthoritiesLookup';
 
-const mockIsPaginationClicked = { current: false };
 const mockHandleLoadMore = jest.fn();
 
 jest.mock('@folio/stripes-authority-components', () => ({
   ...jest.requireActual('@folio/stripes-authority-components'),
   useAuthoritiesBrowse: jest.fn(),
-  useBrowseResultFocus: jest.fn(),
 }));
 
 jest.mock('../../components/AuthoritiesLookup', () => jest.fn(() => <div>AuthoritiesLookup</div>));
@@ -39,8 +34,6 @@ const renderBrowseView = (props = {}) => render(
 
 describe('Given BrowseView', () => {
   beforeEach(() => {
-    mockIsPaginationClicked.current = false;
-
     useAuthoritiesBrowse.mockReturnValue({
       authorities: [],
       hasNextPage: false,
@@ -50,10 +43,6 @@ describe('Given BrowseView', () => {
       handleLoadMore: mockHandleLoadMore,
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
       totalRecords: 0,
-    });
-    useBrowseResultFocus.mockReturnValue({
-      resultsContainerRef: { current: null },
-      isPaginationClicked: mockIsPaginationClicked,
     });
   });
 
@@ -83,8 +72,8 @@ describe('Given BrowseView', () => {
       onNeedMoreData: expect.any(Function),
       onSubmitSearch: expect.any(Function),
       onLinkRecord: mockOnLinkRecord,
+      pagingOffset: 0,
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
-      resultsContainerRef: { current: null },
       searchQuery: '',
       tenantId: '',
       totalRecords: 0,
@@ -95,14 +84,13 @@ describe('Given BrowseView', () => {
   });
 
   describe('when a user clicks on the pagination button', () => {
-    it('should invoke handleLoadMore and assign isPaginationClicked to true', async () => {
+    it('should invoke handleLoadMore', async () => {
       const args = [100, 95, 0, 'next'];
 
       renderBrowseView();
       await act(() => { AuthoritiesLookup.mock.calls[0][0].onNeedMoreData(...args); });
 
       expect(mockHandleLoadMore).toHaveBeenCalledWith(...args);
-      expect(mockIsPaginationClicked.current).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Purpose
Don't clear previous Search/Browse results to highlight the edited record.

## Approach
Keeping previous results fixes the current issue, but occasionally leads to incorrect row focus in the `Browse` search after clicking the pagination buttons (when the previous page has fewer results than the next one) ([UIPFAUTH-51](https://issues.folio.org/browse/UIPFAUTH-51)) 

The newly added `pagingOffset` prop in the `stripes-components` allows always focus on the first row after pagination buttons are clicked.

## Issue
[UIPFAUTH-80](https://issues.folio.org/browse/UIPFAUTH-80)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/110
https://github.com/folio-org/ui-marc-authorities/pull/315


## Screencast



https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/7a7cc127-434c-48b3-ba69-67d06402e27d


