### PR TITLE
UIPFAUTH-81: Remove unnecessary pagingOffset prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [UIPFAUTH-77](https://issues.folio.org/browse/UIPFAUTH-77) Hide the Shared facet in the plugin for the shared bib record.
 * [UIPFAUTH-79](https://issues.folio.org/browse/UIPFAUTH-79) *BREAKING* bump `react-intl` to `v6.4.4`.
 * [UIPFAUTH-80](https://issues.folio.org/browse/UIPFAUTH-80) Don't clear previous Search/Browse results to highlight the edited record.
+* [UIPFAUTH-81](https://issues.folio.org/browse/UIPFAUTH-81) Remove unnecessary pagingOffset prop.
 
 ## [2.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v2.0.0) (2023-02-24)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -49,7 +49,6 @@ const propTypes = {
   onLinkRecord: PropTypes.func.isRequired,
   onNeedMoreData: PropTypes.func.isRequired,
   onSubmitSearch: PropTypes.func.isRequired,
-  pagingOffset: PropTypes.number,
   query: PropTypes.string,
   searchQuery: PropTypes.string.isRequired,
   tenantId: PropTypes.string,
@@ -70,7 +69,6 @@ const AuthoritiesLookup = ({
   hasPrevPage,
   hidePageIndices,
   tenantId,
-  pagingOffset,
   onNeedMoreData,
   onSubmitSearch,
   onLinkRecord,
@@ -232,7 +230,6 @@ const AuthoritiesLookup = ({
         formatter={formatter}
         totalResults={totalRecords}
         pageSize={PAGE_SIZE}
-        pagingOffset={pagingOffset}
         onNeedMoreData={onNeedMoreData}
         loading={isLoading}
         loaded={isLoaded}
@@ -285,7 +282,6 @@ AuthoritiesLookup.defaultProps = {
   hasNextPage: null,
   hasPrevPage: null,
   hidePageIndices: false,
-  pagingOffset: undefined, // undefined is required
   tenantId: '',
 };
 

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -104,7 +104,6 @@ const BrowseView = ({
       hasNextPage={hasNextPage}
       hasPrevPage={hasPrevPage}
       hidePageIndices
-      pagingOffset={0} // any number allows us to always focus on the first row after the pagination change.
       tenantId={tenantId}
       onNeedMoreData={handleLoadMore}
       onSubmitSearch={onSubmitSearch}

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -72,7 +72,6 @@ describe('Given BrowseView', () => {
       onNeedMoreData: expect.any(Function),
       onSubmitSearch: expect.any(Function),
       onLinkRecord: mockOnLinkRecord,
-      pagingOffset: 0,
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
       searchQuery: '',
       tenantId: '',


### PR DESCRIPTION
## Purpose
Remove unnecessary `pagingOffset` prop.

## Issue
[UIPFAUTH-81](https://issues.folio.org/browse/UIPFAUTH-81)

## Related PRs
https://github.com/folio-org/stripes-components/pull/2126
https://github.com/folio-org/stripes-authority-components/pull/111
https://github.com/folio-org/ui-marc-authorities/pull/317

