### PR TITLE
UIPFAUTH-72: Remove eslint deps that are already listed in eslint-config-stripes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.1.0] (IN PROGRESS)
 
 * [UIPFAUTH-83](https://issues.folio.org/browse/UIPFAUTH-83) Resolve circular dependency with ui-quick-marc. Clone QuickMarcView component from `ui-quick-marc`.
+* [UIPFAUTH-72](https://issues.folio.org/browse/UIPFAUTH-72) Remove eslint deps that are already listed in eslint-config-stripes.
 
 ## [3.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v3.0.0) (2023-10-13)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-authority",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Stripes plugin to find authorities",
   "repository": "folio-org/ui-plugin-find-authority",
   "publishConfig": {
@@ -33,7 +33,6 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-plugin-find-authority ./translations/ui-plugin-find-authority/compiled"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.17.0",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/jest-config-stripes": "^2.0.0",
     "@folio/stripes": "^9.0.0",


### PR DESCRIPTION
## Purpose
Remove eslint deps that are already listed in eslint-config-stripes.

## Issue
[UIPFAUTH-72](https://issues.folio.org/browse/UIPFAUTH-72)