### PR TITLE
UIPFAUTH-86: Add new column called Authority source for the browse and search results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.0.0] (IN PROGRESS)
 
 * [UIPFAUTH-85](https://issues.folio.org/browse/UIPFAUTH-85) *BREAKING* Import MarcView from stripes-marc-components.
+* [UIPFAUTH-86](https://issues.folio.org/browse/UIPFAUTH-86) Add new column called Authority source for the browse and search results.
 
 ## [3.1.0] (IN PROGRESS)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -87,9 +87,10 @@ const AuthoritiesLookup = ({
 
   const columnMapping = {
     [searchResultListColumns.LINK]: intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.link' }),
-    [searchResultListColumns.AUTH_REF_TYPE]: intl.formatMessage({ id: 'ui-plugin-find-authority.search-results-list.authRefType' }),
+    [searchResultListColumns.AUTH_REF_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.authRefType' }),
     [searchResultListColumns.HEADING_REF]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingRef' }),
     [searchResultListColumns.HEADING_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingType' }),
+    [searchResultListColumns.AUTHORITY_SOURCE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.authoritySource' }),
   };
 
   const handleLinkRecord = authority => {
@@ -133,6 +134,7 @@ const AuthoritiesLookup = ({
     searchResultListColumns.AUTH_REF_TYPE,
     searchResultListColumns.HEADING_REF,
     searchResultListColumns.HEADING_TYPE,
+    searchResultListColumns.AUTHORITY_SOURCE,
   ];
 
   const toggleFilterPane = () => setIsFilterPaneVisible(!isFilterPaneVisible);

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.test.js
@@ -163,4 +163,14 @@ describe('Given AuthoritiesLookup', () => {
       expect(getByText('stripes-authority-components.search.shared')).toBeInTheDocument();
     });
   });
+
+  it('should display columns', () => {
+    const { getByRole } = renderAuthoritiesSearchPane();
+
+    expect(getByRole('columnheader', { name: 'ui-plugin-find-authority.search-results-list.link' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authRefType' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingRef' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingType' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authoritySource' })).toBeVisible();
+  });
 });

--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -5,4 +5,5 @@ export const columnWidths = {
   [searchResultListColumns.AUTH_REF_TYPE]: { min: 140, max: 150 },
   [searchResultListColumns.HEADING_REF]: { min: 370, max: 370 },
   [searchResultListColumns.HEADING_TYPE]: { min: 120, max: 140 },
+  [searchResultListColumns.AUTHORITY_SOURCE]: '250px',
 };

--- a/translations/ui-plugin-find-authority/en.json
+++ b/translations/ui-plugin-find-authority/en.json
@@ -3,7 +3,6 @@
   "linkToMarcAuthorityRecord": "Link to MARC authority record",
   "modal.title": "Select MARC authority",
   "search-results-list.paneSub": "{totalRecords, number} {totalRecords, plural, one {result found} other {results found}}",
-  "search-results-list.authRefType": "Authorized/Reference",
   "search-results-list.link": "Link",
   "button.link": "Link",
   "button.link.tooltip": "Link \"{fieldValue}\""


### PR DESCRIPTION
## Purpose
Add a new column called `Authority source` for the browse and search results.

## Issues
[UIPFAUTH-86](https://issues.folio.org/browse/UIPFAUTH-86)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/126
https://github.com/folio-org/ui-marc-authorities/pull/328

## Screencast

https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/bff2f1fc-c3db-4f80-b907-2ca0effa6978

