### PR TITLE
UIPFAUTH-87 Use first page Browse query for facet requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIPFAUTH-85](https://issues.folio.org/browse/UIPFAUTH-85) *BREAKING* Import MarcView from stripes-marc-components.
 * [UIPFAUTH-86](https://issues.folio.org/browse/UIPFAUTH-86) Add new column called Authority source for the browse and search results.
+* [UIPFAUTH-87](https://issues.folio.org/browse/UIPFAUTH-87) Use first page Browse query for facet requests.
 
 ## [3.1.0] (IN PROGRESS)
 

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -55,7 +55,7 @@ const BrowseView = ({
     isLoading,
     isLoaded,
     handleLoadMore,
-    query,
+    firstPageQuery,
     totalRecords,
   } = useAuthoritiesBrowse({
     filters,
@@ -96,7 +96,7 @@ const BrowseView = ({
       excludedFilters={excludedFilters}
       totalRecords={totalRecords}
       searchQuery={searchQuery}
-      query={query}
+      query={firstPageQuery}
       isLinkingLoading={isLinkingLoading}
       isLoaded={isLoaded}
       isLoading={isLoading}

--- a/src/views/BrowseView/BrowseView.test.js
+++ b/src/views/BrowseView/BrowseView.test.js
@@ -42,6 +42,7 @@ describe('Given BrowseView', () => {
       isLoaded: false,
       handleLoadMore: mockHandleLoadMore,
       query: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
+      firstPageQuery: '(headingRef>="" or headingRef<"") and isTitleHeadingRef==false',
       totalRecords: 0,
     });
   });


### PR DESCRIPTION
## Description
Fix Facet counts changing when going Next or Prev page in Browse
Use first page query to fetch Browse facets

## Screenshots

https://github.com/folio-org/ui-plugin-find-authority/assets/19309423/8696576a-ae72-4e00-8c9f-68512a33193a



## Issues
[UIPFAUTH-87](https://issues.folio.org/browse/UIPFAUTH-87)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/333
https://github.com/folio-org/stripes-authority-components/pull/130