### PR TITLE
UIPFAUTH-94: Change `useAutoOpenDetailView` hook arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-find-authority
 
+## [4.0.1] IN PROGRESS
+
+* [UIPFAUTH-94](https://issues.folio.org/browse/UIPFAUTH-94) Change `useAutoOpenDetailView` hook arguments.
+
 ## [4.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v4.0.0) (2024-03-21)
 
 * [UIPFAUTH-85](https://issues.folio.org/browse/UIPFAUTH-85) *BREAKING* Import MarcView from stripes-marc-components.

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -171,7 +171,7 @@ const AuthoritiesLookup = ({
     onSubmitSearch(e, ...rest);
   };
 
-  useAutoOpenDetailView(authorities, openDetailView);
+  useAutoOpenDetailView({ authorities, onOpenDetailView: openDetailView });
 
   const renderPaneSub = () => {
     if (navigationSegmentValue === navigationSegments.browse) {


### PR DESCRIPTION
## Purpose
Change the `useAutoOpenDetailView` hook arguments to line with new updates there.

## Description
https://github.com/folio-org/ui-marc-authorities/pull/386

## Issue
[UIPFAUTH-94](https://folio-org.atlassian.net/browse/UIPFAUTH-94)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/144
https://github.com/folio-org/ui-marc-authorities/pull/386
