### PR TITLE
UIPFAUTH-96: Pass the record search error to the `SearchResultsList` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIPFAUTH-86](https://issues.folio.org/browse/UIPFAUTH-86) Add new column called Authority source for the browse and search results.
 * [UIPFAUTH-72](https://issues.folio.org/browse/UIPFAUTH-72) Remove eslint deps that are already listed in eslint-config-stripes.
 * [UIPFAUTH-92](https://issues.folio.org/browse/UIPFAUTH-92) Use `null` for empty value of tenantId instead of empty string.
+* [UIPFAUTH-96](https://issues.folio.org/browse/UIPFAUTH-96) Pass the record search error to the `SearchResultsList` component.
 
 ## [3.0.2] (https://github.com/folio-org/ui-plugin-find-authority/tree/v3.0.2) (2023-11-30)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -38,6 +38,7 @@ import css from './AuthoritiesLookup.css';
 
 const propTypes = {
   authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
+  error: PropTypes.object,
   excludedFilters: PropTypes.object,
   hasFilters: PropTypes.bool.isRequired,
   hasNextPage: PropTypes.bool,
@@ -58,6 +59,7 @@ const propTypes = {
 const AuthoritiesLookup = ({
   authorities,
   excludedFilters,
+  error,
   totalRecords,
   searchQuery,
   query,
@@ -229,6 +231,7 @@ const AuthoritiesLookup = ({
         authorities={authorities}
         columnWidths={columnWidths}
         columnMapping={columnMapping}
+        error={error}
         formatter={formatter}
         totalResults={totalRecords}
         pageSize={PAGE_SIZE}
@@ -279,6 +282,7 @@ const AuthoritiesLookup = ({
 AuthoritiesLookup.propTypes = propTypes;
 
 AuthoritiesLookup.defaultProps = {
+  error: null,
   excludedFilters: {},
   query: '',
   hasNextPage: null,

--- a/src/views/BrowseView/BrowseView.js
+++ b/src/views/BrowseView/BrowseView.js
@@ -57,6 +57,7 @@ const BrowseView = ({
     handleLoadMore,
     firstPageQuery,
     totalRecords,
+    error,
   } = useAuthoritiesBrowse({
     filters,
     searchQuery,
@@ -94,6 +95,7 @@ const BrowseView = ({
     <AuthoritiesLookup
       authorities={formattedAuthoritiesForView}
       excludedFilters={excludedFilters}
+      error={error}
       totalRecords={totalRecords}
       searchQuery={searchQuery}
       query={firstPageQuery}

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -50,6 +50,7 @@ const SearchView = ({
     isLoaded,
     totalRecords,
     query,
+    error,
   } = useAuthorities({
     searchQuery,
     searchIndex,
@@ -77,6 +78,7 @@ const SearchView = ({
     <AuthoritiesLookup
       authorities={authorities}
       excludedFilters={excludedFilters}
+      error={error}
       totalRecords={totalRecords}
       searchQuery={searchQuery}
       query={query}


### PR DESCRIPTION
## Purpose
Pass the record search error to the `SearchResultsList` component.

## Issues
[UIPFAUTH-96](https://folio-org.atlassian.net/browse/UIPFAUTH-96)