### PR TITLE
UIPFAUTH-104 Pass `firstPageQuery` to `<AuthoritiesSearchPane>` to include query in facets request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIPFAUTH-96](https://issues.folio.org/browse/UIPFAUTH-96) Pass the record search error to the `SearchResultsList` component.
 * [UIPFAUTH-100](https://issues.folio.org/browse/UIPFAUTH-100) Migrate to shared CI workflows.
+* [UIPFAUTH-104](https://issues.folio.org/browse/UIPFAUTH-104) Pass `firstPageQuery` to `<AuthoritiesSearchPane>` to include query in facets request.
 
 ## [4.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v4.0.0) (2024-03-21)
 

--- a/src/components/AuthoritiesLookup/AuthoritiesLookup.js
+++ b/src/components/AuthoritiesLookup/AuthoritiesLookup.js
@@ -262,6 +262,7 @@ const AuthoritiesLookup = ({
         isLoading={isLoading}
         onSubmitSearch={handleSubmitSearch}
         query={query}
+        firstPageQuery={query}
         tenantId={tenantId}
         onShowDetailView={setShowDetailView}
       />


### PR DESCRIPTION
## Description
Fix issue with facet counts not changing when using different browse options.
It was caused by missing query parameters in `useFacets` request so all facets requests were sent with `id=*`.
We need to pass `firstPageQuery` prop to `<AuthoritiesSearchPane>` to pass the query to facets requests.

## Screenshots

https://github.com/user-attachments/assets/731c6303-3652-4193-b0c2-39daea12a005

## Issues
[UIPFAUTH-104](https://folio-org.atlassian.net/browse/UIPFAUTH-104)