### PR TITLE
migrate stripes deps and react-intl to sunflower versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history for ui-plugin-find-authority
 
+## [5.0.0] (IN PROGRESS)
+
+* [UIPFAUTH-106](https://issues.folio.org/browse/UIPFAUTH-106) *BREAKING* migrate stripes dependencies to their Sunflower versions
+* [UIPFAUTH-107](https://issues.folio.org/browse/UIPFAUTH-107) *BREAKING* migrate react-intl to v7
+
+
 ## [4.1.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v4.1.0) (2024-11-01)
 
 * [UIPFAUTH-96](https://issues.folio.org/browse/UIPFAUTH-96) Pass the record search error to the `SearchResultsList` component.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-authority",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Stripes plugin to find authorities",
   "repository": "folio-org/ui-plugin-find-authority",
   "publishConfig": {
@@ -30,18 +30,17 @@
     "test": "jest --coverage --verbose",
     "test:color": "jest --coverage --verbose --color",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-plugin-find-authority ./translations/ui-plugin-find-authority/compiled"
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^7.0.0",
-    "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.0.0",
-    "@folio/stripes-authority-components": "^4.0.0",
-    "@folio/stripes-marc-components": "^1.0.0",
-    "@folio/stripes-cli": "^3.0.0",
-    "@folio/stripes-core": "^10.0.0",
-    "@folio/stripes-testing": "^4.2.0",
-    "@formatjs/cli": "^6.1.3",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-authority-components": "^6.0.0",
+    "@folio/stripes-marc-components": "^2.0.0",
+    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-core": "^11.0.0",
+    "@folio/stripes-testing": "^5.0.0",
     "core-js": "^3.6.4",
     "eslint-plugin-jest": "^26.6.0",
     "identity-obj-proxy": "^3.0.0",
@@ -49,7 +48,7 @@
     "prop-types": "^15.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.3"
   },
@@ -57,12 +56,12 @@
     "query-string": "^7.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.0.0",
-    "@folio/stripes-authority-components": "^4.0.0",
-    "@folio/stripes-marc-components": "^1.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-authority-components": "^6.0.0",
+    "@folio/stripes-marc-components": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   }
 }


### PR DESCRIPTION
## Description
migrate stripes deps and react-intl to sunflower versions

## Issues
[UIPFAUTH-106](https://folio-org.atlassian.net/browse/UIPFAUTH-106)
[UIPFAUTH-107](https://folio-org.atlassian.net/browse/UIPFAUTH-107)