### PR TITLE
UIPFAUTH-110 Find Authority > Authority View - show Last updated by date from mod-search metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-find-authority
 
+## [5.1.0] (IN PROGRESS)
+
+* [UIPFAUTH-110](https://issues.folio.org/browse/UIPFAUTH-110) Find Authority > Authority View - show Last updated by date from mod-search metadata.
+
 ## [5.0.0] (https://github.com/folio-org/ui-plugin-find-authority/tree/v5.0.0) (2025-03-13)
 
 * [UIPFAUTH-106](https://issues.folio.org/browse/UIPFAUTH-106) *BREAKING* migrate stripes dependencies to their Sunflower versions

--- a/src/components/MarcAuthorityView/MarcAuthorityView.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.js
@@ -134,7 +134,7 @@ const MarcAuthorityView = ({
 
   const paneSub = intl.formatMessage({ id: 'stripes-authority-components.authorityRecordSubtitle' }, {
     heading: authority.data.headingType,
-    lastUpdatedDate: intl.formatDate(marcSource.data.metadata.updatedDate),
+    lastUpdatedDate: intl.formatDate(authority.data.metadata.updatedDate),
   });
 
   return (

--- a/src/components/MarcAuthorityView/MarcAuthorityView.test.js
+++ b/src/components/MarcAuthorityView/MarcAuthorityView.test.js
@@ -72,10 +72,6 @@ const marcSource = {
         }],
       },
     },
-    metadata: {
-      lastUpdatedDate: '2020-12-04T09:05:30.000+0000',
-      updatedDate: '',
-    },
   },
   isLoading: false,
 };
@@ -85,6 +81,9 @@ const authority = {
     id: 'authority-id',
     headingRef: 'heading-ref',
     authRefType: 'Authorized',
+    metadata: {
+      updatedDate: '2020-12-04T09:05:30.000+0000',
+    },
   },
   isLoading: false,
 };


### PR DESCRIPTION
## Description
Previously we used metadata from MARC Authority records (from SRS), but in some cases it could be different from metadata in mod-search.
Because of this discrepancy "Date update" filter returned results that did not match the dates in the MARC Authority view.
To fix this we should use metadata from mod-search response.

## Issues
[UIPFAUTH-110](https://folio-org.atlassian.net/browse/UIPFAUTH-110)